### PR TITLE
Gamma peak fits: bug fix and plot receipe

### DIFF
--- a/ext/LegendSpecFitsRecipesBaseExt.jl
+++ b/ext/LegendSpecFitsRecipesBaseExt.jl
@@ -238,13 +238,13 @@ end
     end
 end
 
-@recipe function f(report::NamedTuple{(:v, :h, :f_fit, :f_sig, :f_lowEtail, :f_bck, :gof)}, mode::Symbol = :cormat)
+@recipe function f(report::NamedTuple{(:v, :h, :f_fit, :f_sig, :f_lowEtail, :f_bck, :gof)}, mode::Symbol)
     if mode == :cormat 
         cm = cor(report.gof.covmat)
     elseif  mode == :covmat
         cm = report.gof.covmat
     else
-        @debug "mode $mode not supported"
+        @debug "mode $mode not supported - has to be :cormat or :covmat"
         return
     end
    

--- a/ext/LegendSpecFitsRecipesBaseExt.jl
+++ b/ext/LegendSpecFitsRecipesBaseExt.jl
@@ -238,6 +238,61 @@ end
     end
 end
 
+@recipe function f(report::NamedTuple{(:v, :h, :f_fit, :f_sig, :f_lowEtail, :f_bck, :gof)}, cormat::Bool = true)
+    cm = cor(report.gof.covmat)
+    cm_plt  = NaN .* cm
+    for i in range(1, stop = size(cm)[1])
+        cm_plt[i:end,i] = cm[i:end,i]
+    end
+
+    # prepare labels 
+    par_names = fieldnames(report.v)
+    tick_names =  String.(collect(par_names))
+    tick_names[tick_names .== "step_amplitude"] .= L"\textrm{bkg}_\textrm{step}"
+    tick_names[tick_names .== "background"] .= "bkg"
+    tick_names[tick_names .== "skew_width"] .= L"\textrm{tail}_\textrm{skew}"
+    tick_names[tick_names .== "skew_fraction"] .= L"\textrm{tail}_\textrm{frac}"
+
+    @series begin
+        seriestype := :heatmap
+       # c := cgrad(:grays, rev = true)
+       c := :RdBu_3#:bam
+        cm_plt
+    end
+
+    # annotation for correlation coefficient 
+    cm_vec = round.(vec(cm_plt), digits = 2)
+    xvec  = vec(hcat([fill(i, 7) for i in 1:7]...))
+    yvec  = vec(hcat([fill(i, 7) for i in 1:7]...)')
+    xvec = xvec[isfinite.(cm_vec)]
+    yvec = yvec[isfinite.(cm_vec)]
+    cm_vec = cm_vec[isfinite.(cm_vec)]
+    @series begin
+        seriestype := :scatter
+        xticks := (1:length(par_names),tick_names)
+        yticks := (1:length(par_names),tick_names)
+        yflip := true
+        markeralpha := 0
+        colorbar := false 
+        label := false
+        legend := false
+        thickness_scaling := 1.0
+        xtickfontsize := 12
+        xlabelfontsize := 14
+        ylabelfontsize := 14
+        tickfontsize:= 12
+        legendfontsize := 10
+        xlims := (0.5, 7.5)
+        ylims := (0.5, 7.5)
+        size := (600, 575)
+        grid := false
+        title := "Correlation Matrix" 
+        series_annotations := [("$(cm_vec[i])", :center, :center, :black, 12, "Helvetica Bold") for i in eachindex(xvec)]
+        xvec, yvec
+    end
+
+end
+
 @recipe function f(report::NamedTuple{((:v, :h, :f_fit, :f_sig, :f_bck))}; f_fit_x_step_scaling=1/100)
     f_fit_x_step = ustrip(value(report.v.σ)) * f_fit_x_step_scaling
     xlabel := "A/E (a.u.)"

--- a/ext/LegendSpecFitsRecipesBaseExt.jl
+++ b/ext/LegendSpecFitsRecipesBaseExt.jl
@@ -279,22 +279,22 @@ end
         seriestype := :scatter
         xticks := (1:length(par_names),tick_names)
         yticks := (1:length(par_names),tick_names)
-        yflip := true
+        yflip --> true
         markeralpha := 0
-        colorbar := false 
-        label := false
-        legend := false
+        colorbar --> false 
+        label --> false
+        legend --> false
         thickness_scaling := 1.0
-        xtickfontsize := 12
-        xlabelfontsize := 14
-        ylabelfontsize := 14
-        tickfontsize:= 12
-        legendfontsize := 10
-        xlims := (0.5, 7.5)
-        ylims := (0.5, 7.5)
-        size := (600, 575)
-        grid := false
-        title := "Correlation Matrix" 
+        xtickfontsize --> 12
+        xlabelfontsize --> 14
+        ylabelfontsize --> 14
+        tickfontsize --> 12
+        legendfontsize --> 10
+        xlims --> (0.5, length(par_names)+0.5)
+        ylims --> (0.5, length(par_names)+0.5)
+        size --> (600, 575)
+        grid --> false
+        title --> "Correlation Matrix" 
         series_annotations := [("$(cm_vec[i])", :center, :center, :black, 12, "Helvetica Bold") for i in eachindex(xvec)]
         xvec, yvec
     end

--- a/ext/LegendSpecFitsRecipesBaseExt.jl
+++ b/ext/LegendSpecFitsRecipesBaseExt.jl
@@ -238,8 +238,16 @@ end
     end
 end
 
-@recipe function f(report::NamedTuple{(:v, :h, :f_fit, :f_sig, :f_lowEtail, :f_bck, :gof)}, cormat::Bool = true)
-    cm = cor(report.gof.covmat)
+@recipe function f(report::NamedTuple{(:v, :h, :f_fit, :f_sig, :f_lowEtail, :f_bck, :gof)}, mode::Symbol = :cormat)
+    if mode == :cormat 
+        cm = cor(report.gof.covmat)
+    elseif  mode == :covmat
+        cm = report.gof.covmat
+    else
+        @debug "mode $mode not supported"
+        return
+    end
+   
     cm_plt  = NaN .* cm
     for i in range(1, stop = size(cm)[1])
         cm_plt[i:end,i] = cm[i:end,i]

--- a/src/specfit.jl
+++ b/src/specfit.jl
@@ -168,9 +168,10 @@ function fit_single_peak_th228(h::Histogram, ps::NamedTuple{(:peak_pos, :peak_fw
         n = weibull_from_mx(ps.peak_counts, 2*ps.peak_counts),
         step_amplitude = weibull_from_mx(ps.mean_background_step, ps.mean_background_step + 5*ps.mean_background_std),
         skew_fraction = ifelse(low_e_tail, truncated(weibull_from_mx(0.01, 0.05), 0.0, 0.25), ConstValueDist(0.0)),
-        skew_width = ifelse(low_e_tail, weibull_from_mx(0.001, 1e-3), ConstValueDist(1.0)),
+        skew_width = ifelse(low_e_tail, weibull_from_mx(0.001, 1e-2), ConstValueDist(1.0)),
         background = weibull_from_mx(ps.mean_background, ps.mean_background + 5*ps.mean_background_std),
     )
+
     # use standard priors in case of no overwrites given
     if !(:empty in keys(pseudo_prior))
         # check if input overwrite prior has the same fields as the standard prior set


### PR DESCRIPTION
- bug fix `pseudo_prior`: set standard 68.27% quantile to 1e-2
- add plot receipe for covarince and correlation matrix for peak fit report (`_, report = fit_single_peak_th228`)
       - plot(report,:cormat) for correlation matrix
       - plot(report,:covmat) for covariance matrix