### PR TITLE
Lq updated

### DIFF
--- a/ext/LegendSpecFitsRecipesBaseExt.jl
+++ b/ext/LegendSpecFitsRecipesBaseExt.jl
@@ -1105,12 +1105,14 @@ end
     if plot_type == :DEP
         # Create 2D histogram with filtered data based on DEP_left and DEP_right
         
-        # dynamic bin size
-        xmin = ustrip.(minimum(dt_DEP))
-        xmax = ustrip.(maximum(dt_DEP))
+        # dynamic bin size dependant on fit constraint box
+        t_diff = box.t_upper - box.t_lower
+        lq_diff = box.lq_upper - box.lq_lower
+        xmin = box.t_lower - 1*t_diff
+        xmax = box.t_upper + 1*t_diff
         xstep = (xmax - xmin) / 100 
-        ymin = ustrip.(minimum(lq_DEP))
-        ymax = ustrip.(quantile(lq_DEP, 0.92))
+        ymin = box.lq_lower - 1*lq_diff
+        ymax = box.lq_upper + 4*lq_diff
         ystep = (ymax - ymin) / 100
         nbins := (xmin:xstep:xmax, ymin:ystep:ymax)
 
@@ -1124,10 +1126,10 @@ end
 
         # dynamic bin size
         xmin = ustrip.(quantile(dt_eff, 0.001))
-        xmax = ustrip.(quantile(dt_eff, 0.99))
+        xmax = ustrip.(quantile(dt_eff, 0.999))
         xstep = (xmax - xmin) / 200
         ymin = ustrip.(quantile(lq_e_corr[.!isnan.(lq_e_corr)], 0.005)) #filters NaNs for quantile
-        ymax = ustrip.(quantile(lq_e_corr[.!isnan.(lq_e_corr)], 0.93)) #filters NaNs for quantile
+        ymax = ustrip.(quantile(lq_e_corr[.!isnan.(lq_e_corr)], 0.94)) #filters NaNs for quantile
         ystep = (ymax - ymin) / 200
         nbins := (xmin:xstep:xmax, ymin:ystep:ymax)
 

--- a/src/aoe_cut.jl
+++ b/src/aoe_cut.jl
@@ -123,7 +123,7 @@ get_peaks_surrival_fractions(aoe, e, peaks, peak_names, left_window_sizes::Vecto
 
 
 """
-    get_peak_surrival_fraction(aoe::Array{T}, e::Array{T}, peak::T, window::Array{T}, aoe_cut::T,; uncertainty::Bool=true, low_e_tail::Bool=true) where T<:Real
+    get_peak_surrival_fraction(aoe::Vector{<:Unitful.RealOrRealQuantity}, e::Vector{<:T}, peak::T, window::Vector{T}, aoe_cut::Unitful.RealOrRealQuantity,; uncertainty::Bool=true, inverted_mode::Bool=false, low_e_tail::Bool=true, bin_width_window::T=2.0u"keV", sigma_high_sided::Unitful.RealOrRealQuantity=NaN) where T<:Unitful.Energy{<:Real}
 
 Get the surrival fraction of a peak after a AoE cut value `aoe_cut` for a given `peak` and `window` size while performing a peak fit with fixed position.
     
@@ -192,7 +192,7 @@ export get_peak_surrival_fraction
 
 
 """
-    get_continuum_surrival_fraction(aoe:::Vector{<:Unitful.RealOrRealQuantity}, e::Vector{<:T}, center::T, window::T, aoe_cut::Unitful.RealOrRealQuantity,; sigma_high_sided::Unitful.RealOrRealQuantity=NaN) where T<:Unitful.Energy{<:Real}
+    get_continuum_surrival_fraction(aoe::Vector{<:Unitful.RealOrRealQuantity}, e::Vector{<:T}, center::T, window::T, aoe_cut::Unitful.RealOrRealQuantity,; inverted_mode::Bool=false, sigma_high_sided::Unitful.RealOrRealQuantity=NaN) where T<:Unitful.Energy{<:Real}
 
 Get the surrival fraction of a continuum after a AoE cut value `aoe_cut` for a given `center` and `window` size.
 
@@ -211,7 +211,8 @@ function get_continuum_surrival_fraction(aoe::Vector{<:Unitful.RealOrRealQuantit
     if !isnan(sigma_high_sided)
         n_after = length(e[aoe_cut .< aoe .< sigma_high_sided .&& center - window .< e .< center + window])
     end
-    if lq_mode == true
+    #inverted mode for lq cut
+    if inverted_mode == true
         n_after = length(e[aoe .< aoe_cut .&& center - window .< e .< center + window])
     end
 

--- a/src/lqcut.jl
+++ b/src/lqcut.jl
@@ -41,7 +41,7 @@ function lq_drift_time_correction(
 
     # dt_eff_DEP cutoff; method dependant on detector type
     
-    if mode == :percentile #standard method; can be used for all detectors
+    if mode == :percentile # standard method; can be used for all detectors
         #set cutoff; default at the 15% and 95% percentile
         t_lower = quantile(dt_eff_DEP, dt_eff_low_quantile)
         t_upper = quantile(dt_eff_DEP, dt_eff_high_quantile)
@@ -68,7 +68,7 @@ function lq_drift_time_correction(
         t_lower = µ_t - drift_cutoff_sigma * σ_t
         t_upper = µ_t + drift_cutoff_sigma * σ_t
 
-    elseif mode == :double_gaussian # can be used for detectors with double peaks
+    elseif mode == :double_gaussian # can be used for detectors with double peaks; not optimized yet
         #create histogram for drift time
         drift_prehist = fit(Histogram, dt_eff_DEP, range(minimum(dt_eff_DEP), stop=maximum(dt_eff_DEP), length=100))
         drift_prestats = estimate_single_peak_stats(drift_prehist)
@@ -181,6 +181,7 @@ function LQ_cut(
     )
 
     report = (
+        cut = cut_3σ,
         fit_result = fit_result,
         temp_hists = temp_hists,
         fit_report = fit_report,

--- a/src/lqcut.jl
+++ b/src/lqcut.jl
@@ -8,7 +8,7 @@ Perform the drift time correction on the LQ data using the DEP peak. The functio
     * `report`: NamedTuple of the histograms used for the fit, the cutoff values and the DEP edges
 """
 function lq_drift_time_correction(
-    lq_norm::Vector{Float64}, dt_eff::Vector{<:Unitful.RealOrRealQuantity}, e_cal::Vector{<:Unitful.Energy{<:Real}}, DEP_µ::Unitful.AbstractQuantity, DEP_σ::Unitful.AbstractQuantity; 
+    lq_norm::Vector{<:AbstractFloat}, dt_eff::Vector{<:Unitful.RealOrRealQuantity}, e_cal::Vector{<:Unitful.Energy{<:Real}}, DEP_µ::Unitful.AbstractQuantity, DEP_σ::Unitful.AbstractQuantity; 
     DEP_edgesigma::Float64=3.0 , mode::Symbol=:percentile, drift_cutoff_sigma::Float64 = 2.0, prehist_sigma::Float64=2.5, e_expression::Union{String,Symbol}="e", dt_eff_low_quantile::Float64=0.15, dt_eff_high_quantile::Float64=0.95)
 
     # get energy units to remve later
@@ -70,7 +70,8 @@ function lq_drift_time_correction(
 
     elseif mode == :double_gaussian # can be used for detectors with double peaks; not optimized yet
         #create histogram for drift time
-        drift_prehist = fit(Histogram, dt_eff_DEP, range(minimum(dt_eff_DEP), stop=maximum(dt_eff_DEP), length=100))
+        ideal_length = get_number_of_bins(dt_eff_DEP)
+        drift_prehist = fit(Histogram, dt_eff_DEP, range(minimum(dt_eff_DEP), stop=maximum(dt_eff_DEP), length=ideal_length))
         drift_prestats = estimate_single_peak_stats(drift_prehist)
 
         #fit histogram with double gaussian
@@ -137,7 +138,7 @@ Evaluates the cutoff value for the LQ cut. The function performs a binned gaussi
     * `report`: NamedTuple of the fit result, fit report and temporary histograms
 """
 function LQ_cut(
-    DEP_µ::Unitful.Energy, DEP_σ::Unitful.Energy, e_cal::Vector{<:Unitful.Energy}, lq_classifier::Vector{Float64}; cut_sigma::Float64=3.0, truncation_sigma::Float64=2.0)
+    DEP_µ::Unitful.Energy, DEP_σ::Unitful.Energy, e_cal::Vector{<:Unitful.Energy}, lq_classifier::Vector{<:AbstractFloat}; cut_sigma::Float64=3.0, truncation_sigma::Float64=2.0)
 
     # Define sidebands
     lq_DEP = lq_classifier[DEP_µ - 4.5 * DEP_σ .< e_cal .< DEP_µ + 4.5 * DEP_σ]

--- a/src/lqcut.jl
+++ b/src/lqcut.jl
@@ -1,11 +1,11 @@
 """
-    lq_norm::Vector{Float64}, dt_eff::Vector{<:Unitful.RealOrRealQuantity}, e_cal::Array{<:Unitful.Energy{<:Real}}, DEP_µ::Unitful.AbstractQuantity, DEP_σ::Unitful.AbstractQuantity;
-    DEP_edgesigma::Float64 = 3.0 , mode::Symbol = :gaussian, lower_exclusion::Float64 = 0.005, upper_exclusion::Float64 = 0.98, drift_cutoff_sigma::Float64 = 2.0, e_expression::Union{String,Symbol}="e")
+    lq_norm::Vector{Float64}, dt_eff::Vector{<:Unitful.RealOrRealQuantity}, e_cal::Vector{<:Unitful.Energy{<:Real}}, DEP_µ::Unitful.AbstractQuantity, DEP_σ::Unitful.AbstractQuantity; 
+    DEP_edgesigma::Float64=3.0 , mode::Symbol=:percentile, drift_cutoff_sigma::Float64 = 2.0, prehist_sigma::Float64=2.5, e_expression::Union{String,Symbol}="e", dt_eff_low_quantile::Float64=0.15, dt_eff_high_quantile::Float64=0.95)
 
 Perform the drift time correction on the LQ data using the DEP peak. The function cuts outliers in lq and drift time, then performs a linear fit on the remaining data. The data is Corrected by subtracting the linear fit from the lq data.
 # Returns
-    * `result`: NamedTuple of the corrected lq data, the box used for the linear fit and the drift time function
-    * `report`: NamedTuple of the histograms used for the fit
+    * `result`: NamedTuple of the function used for lq classifier construction
+    * `report`: NamedTuple of the histograms used for the fit, the cutoff values and the DEP edges
 """
 function lq_drift_time_correction(
     lq_norm::Vector{Float64}, dt_eff::Vector{<:Unitful.RealOrRealQuantity}, e_cal::Vector{<:Unitful.Energy{<:Real}}, DEP_µ::Unitful.AbstractQuantity, DEP_σ::Unitful.AbstractQuantity; 
@@ -129,12 +129,12 @@ end
 export lq_drift_time_correction
 
 """
-    DEP_µ::Unitful.Energy, DEP_σ::Unitful.Energy, e_cal::Vector{<:Unitful.Energy}, lq_classifier::Vector{Float64}; lower_exclusion::Float64=0.005, upper_exclusion::Float64=0.95, cut_sigma::Float64=3.0)
+    DEP_µ::Unitful.Energy, DEP_σ::Unitful.Energy, e_cal::Vector{<:Unitful.Energy}, lq_classifier::Vector{Float64}; cut_sigma::Float64=3.0, truncation_sigma::Float64=2.0)
 
 Evaluates the cutoff value for the LQ cut. The function performs a binned gaussian fit on the sidebandsubtracted LQ histogram and evaluates the cutoff value difined at 3σ of the fit.
 # Returns
-    * `result`: NamedTuple of the cutoff value and the fit result
-    * `report`: NamedTuple of the histograms used for the fit
+    * `result`: NamedTuple of the cutoff value
+    * `report`: NamedTuple of the fit result, fit report and temporary histograms
 """
 function LQ_cut(
     DEP_µ::Unitful.Energy, DEP_σ::Unitful.Energy, e_cal::Vector{<:Unitful.Energy}, lq_classifier::Vector{Float64}; cut_sigma::Float64=3.0, truncation_sigma::Float64=2.0)

--- a/src/lqcut.jl
+++ b/src/lqcut.jl
@@ -12,6 +12,9 @@ function lq_drift_time_correction(
      DEP_edgesigma::Float64 = 3.0 , mode::Symbol = :gaussian, lower_exclusion::Float64 = 0.005, upper_exclusion::Float64 = 0.98, drift_cutoff_sigma::Float64 = 2.0,
      prehist_sigma::Float64 = 3.0, e_expression::Union{String,Symbol}="e")
 
+    #get energy units to remve later
+    e_unit = unit(first(e_cal))
+
     #calculate DEP edges
     DEP_left = DEP_µ - DEP_edgesigma * DEP_σ
     DEP_right = DEP_µ + DEP_edgesigma * DEP_σ
@@ -52,7 +55,7 @@ function lq_drift_time_correction(
         drift_start = drift_prestats.peak_pos - prehist_sigma * drift_prestats.peak_sigma
         drift_stop = drift_prestats.peak_pos + prehist_sigma * drift_prestats.peak_sigma
         
-        drift_edges = range(drift_start, stop=drift_stop, length=ideal_length)
+        drift_edges = range(drift_start, stop=drift_stop, length=100)
         drift_hist_DEP = fit(Histogram, dt_eff_DEP, drift_edges)
         
         drift_result, drift_report = fit_binned_trunc_gauss(drift_hist_DEP)
@@ -104,7 +107,7 @@ function lq_drift_time_correction(
     drift_time_func(x) = parameters[1] .+ parameters[2] .* x
 
     #property function for drift time correction
-    lq_class_func = "lq / $e_expression - ($(parameters[2]) * (qdrift / $e_expression) + $(parameters[1]))"
+    lq_class_func = "(lq / ($(e_expression))$(e_unit)^-1) - ($(parameters[2]) * (qdrift / ($(e_expression))$(e_unit)^-1) + $(parameters[1]))"  #removes the units to get unitless lq classifier
     lq_class_func_generic = "lq / e  - (slope * qdrift / e + y_inter)"
 
     #create result and report

--- a/src/lqcut.jl
+++ b/src/lqcut.jl
@@ -119,7 +119,9 @@ function lq_drift_time_correction(
     drift_prehist = drift_prehist, 
     drift_report = drift_report,
     lq_box = box,
-    drift_time_func = drift_time_func
+    drift_time_func = drift_time_func,
+    DEP_left = DEP_left,
+    DEP_right = DEP_right,
     )
     
 

--- a/src/singlefit.jl
+++ b/src/singlefit.jl
@@ -376,23 +376,24 @@ function fit_binned_trunc_gauss(h_nocut::Histogram, cuts::NamedTuple{(:low, :hig
     x_min, x_max, bin_width = first(h_nocut.edges[1]), last(h_nocut.edges[1]), step(h_nocut.edges[1])
     cut_low, cut_high = ifelse(isnan(cut_low), x_min, cut_low), ifelse(isnan(cut_high), x_max, cut_high)
 
-
     # get peak stats
     ps = estimate_single_peak_stats_simple(h_nocut)
     @debug "Peak stats: $ps"
 
-    # create cutted histogram
-    h = h_nocut
-    cut_idxs = collect(sort(findall(x -> x in Interval(cut_low, cut_high), h.edges[1])))
-    if length(cut_idxs) != length(h.edges[1])
-        weights = h.weights[cut_idxs]
-        edges = if first(cut_idxs)-1 == 0
-            h.edges[1][sort(push!(cut_idxs, last(cut_idxs)-1))]
-        else
-            h.edges[1][sort(push!(cut_idxs, first(cut_idxs)-1))]
-        end
-        h = Histogram(edges, weights)
-    end
+    # get edges and weights
+    edges = h_nocut.edges[1]
+    weights = h_nocut.weights
+
+    # truncate edges to specified range
+    low_idx = findfirst(x -> x >= cut_low, edges)
+    high_idx = findlast(x -> x <= cut_high, edges)
+    
+    # Extract the edges and weights within the range
+    filtered_edges = edges[low_idx:high_idx]  
+    filtered_counts = weights[low_idx:high_idx-1] # Since edge vector is one longer than weights vector, we need to remove the last element
+    
+    # create truncated histogram
+    h = Histogram(filtered_edges, filtered_counts)
 
     # create fit function
     f_fit(x, v) = v.n * gauss_pdf(x, v.μ, v.σ) * heaviside(x - cut_low) * heaviside(cut_high - x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,5 +8,6 @@ Test.@testset "Package LegendSpecFits" begin
     include("test_fit_chisq.jl")
     include("test_singlefit.jl")
     include("test_docs.jl")
+    include("test_lq.jl")
     isempty(Test.detect_ambiguities(LegendSpecFits))
 end # testset

--- a/test/test_lq.jl
+++ b/test/test_lq.jl
@@ -58,7 +58,7 @@ end
 @testset "Test lq_drift_time_correction with Tail" begin
 
     # Generate 10000 data points
-    N = 1000
+    N = 10000
 
     # Generate dt_eff (drift time) with a Gaussian distribution
     dt_mean = 500.0
@@ -66,7 +66,7 @@ end
     dt_eff = (dt_mean .+ dt_std .* randn(N)) .* u"µs"
 
     # Generate lq_norm with a linear dependence on dt_eff + some noise
-    true_slope = 0.001
+    true_slope = 0.002
     true_intercept = 3
     noise_level = 0.1
     lq_norm = true_slope .* ustrip.(dt_eff) .+ true_intercept .+ randn(N) .* noise_level

--- a/test/test_lq.jl
+++ b/test/test_lq.jl
@@ -1,0 +1,51 @@
+
+using LegendSpecFits
+using Unitful
+using Distributions
+using Plots
+
+
+# Define the test function
+@testset "LQ_cut Test" begin
+    # Define energy peak parameters
+    DEP_µ = 1000.0u"keV"
+    DEP_σ = 1.0u"keV"
+    n_peak = 5000  # Peak events
+    n_bg = n_peak ÷ 10  # Background events
+
+    # Energy calibration (fixed at DEP_µ for all events)
+    e_cal = vcat(fill(DEP_µ, n_peak + n_bg), fill(DEP_µ - 5* DEP_σ, n_bg ÷ 2), fill(DEP_µ + 5* DEP_σ, n_bg ÷ 2) )  # Fixed energy value for peak and background
+
+    # LQ Classifier
+    # Peak 1: Normally distributed LQ values
+    lq_classifier_peak1 = randn(n_peak)
+    # Peak 2: Flat background within the peak
+    lq_classifier_peak2 = -3 .+ 20 .* rand(n_bg)
+
+    # Below: Flat background below the peak
+    lq_classifier_below = -3 .+ 20 .* rand(n_bg ÷ 2)
+    lq_classifier_above = -3 .+ 20 .* rand(n_bg ÷ 2)
+
+    # Combine all cases into the LQ classifier array
+    lq_classifier_combined = vcat(lq_classifier_peak1, lq_classifier_peak2, lq_classifier_below, lq_classifier_above)
+
+    # Call the LQ_cut function
+    result, report = LQ_cut(DEP_µ, DEP_σ, e_cal, lq_classifier_combined)
+
+    plot(report.temp_hists.hist_DEP, label="LQ SEP")
+    plot!(report.temp_hists.hist_sb1, label="LQ SB1")
+    plot!(report.temp_hists.hist_sb2, label="LQ SB2")
+    plot!(report.temp_hists.hist_subtracted, label="DEP Subtracted")
+    plot(report.temp_hists.hist_corrected, label="Fit")
+    plot!(report.fit_report.f_fit, label="Fit function")
+
+    # Extract the cutoff value
+    cut_3σ = result.cut
+  
+    # Verify if the cutoff is correctly 3 sigma
+    expected_cut = mean(lq_classifier_peak1) + 3 * std(lq_classifier_peak1)
+
+    @test isapprox(cut_3σ, expected_cut, atol=0.1)
+end
+
+

--- a/test/test_lq.jl
+++ b/test/test_lq.jl
@@ -2,7 +2,7 @@ using Test
 using LegendSpecFits
 using Unitful
 using Distributions
-using Plots
+# using Plots
 
 # Define the test function
 @testset "LQ_cut Test" begin
@@ -31,16 +31,14 @@ using Plots
     # Call the LQ_cut function
     result, report = LQ_cut(DEP_µ, DEP_σ, e_cal, lq_classifier_combined)
 
-    plot(report.temp_hists.hist_DEP, label="LQ SEP")
-    plot!(report.temp_hists.hist_sb1, label="LQ SB1")
-    plot!(report.temp_hists.hist_sb2, label="LQ SB2")
-    plot!(report.temp_hists.hist_subtracted, label="DEP Subtracted")
-    plot(report.temp_hists.hist_corrected, label="original histogram")
-    plot!(report.fit_report.f_fit, label="Fit function")
+    # plot(report.temp_hists.hist_DEP, label="LQ SEP")
+    # plot!(report.temp_hists.hist_sb1, label="LQ SB1")
+    # plot!(report.temp_hists.hist_sb2, label="LQ SB2")
+    # plot!(report.temp_hists.hist_subtracted, label="DEP Subtracted")
+    # plot(report.temp_hists.hist_corrected, label="original histogram")
+    # plot!(report.fit_report.f_fit, label="Fit function")
 
     # Extract the cutoff value
-    report.fit_result.μ
-    report.fit_result.σ
     cut_3σ = result.cut
   
     # Calculate the expected mean, sigma and cutoff value

--- a/test/test_lq.jl
+++ b/test/test_lq.jl
@@ -1,4 +1,4 @@
-
+using Test
 using LegendSpecFits
 using Unitful
 using Distributions
@@ -20,11 +20,11 @@ using Plots
     # Peak 1: Normally distributed LQ values
     lq_classifier_peak1 = randn(n_peak)
     # Peak 2: Flat background within the peak
-    lq_classifier_peak2 = -3 .+ 20 .* rand(n_bg)
+    lq_classifier_peak2 = -4 .+ 14 .* rand(n_bg)
 
     # Below: Flat background below the peak
-    lq_classifier_below = -3 .+ 20 .* rand(n_bg ÷ 2)
-    lq_classifier_above = -3 .+ 20 .* rand(n_bg ÷ 2)
+    lq_classifier_below = -4 .+ 14 .* rand(n_bg ÷ 2)
+    lq_classifier_above = -4 .+ 14 .* rand(n_bg ÷ 2)
 
     # Combine all cases into the LQ classifier array
     lq_classifier_combined = vcat(lq_classifier_peak1, lq_classifier_peak2, lq_classifier_below, lq_classifier_above)
@@ -36,16 +36,21 @@ using Plots
     plot!(report.temp_hists.hist_sb1, label="LQ SB1")
     plot!(report.temp_hists.hist_sb2, label="LQ SB2")
     plot!(report.temp_hists.hist_subtracted, label="DEP Subtracted")
-    plot(report.temp_hists.hist_corrected, label="Fit")
+    plot(report.temp_hists.hist_corrected, label="original histogram")
     plot!(report.fit_report.f_fit, label="Fit function")
 
     # Extract the cutoff value
+    report.fit_result.μ
+    report.fit_result.σ
     cut_3σ = result.cut
   
-    # Verify if the cutoff is correctly 3 sigma
-    expected_cut = mean(lq_classifier_peak1) + 3 * std(lq_classifier_peak1)
+    # Calculate the expected mean, sigma and cutoff value
+    expected_mean = mean(lq_classifier_peak1)
+    expected_sigma = std(lq_classifier_peak1)
+    expected_cut = expected_mean + 3 * expected_sigma
 
+    # Test the parameters
+    @test isapprox(report.fit_result.μ, expected_mean, atol=0.05)
+    @test isapprox(report.fit_result.σ, expected_sigma, atol=0.05)
     @test isapprox(cut_3σ, expected_cut, atol=0.1)
 end
-
-

--- a/test/test_lq.jl
+++ b/test/test_lq.jl
@@ -4,7 +4,6 @@ using Unitful
 using Distributions
 using Plots
 
-
 # Define the test function
 @testset "LQ_cut Test" begin
     # Define energy peak parameters
@@ -54,3 +53,47 @@ using Plots
     @test isapprox(report.fit_result.σ, expected_sigma, atol=0.05)
     @test isapprox(cut_3σ, expected_cut, atol=0.1)
 end
+
+
+@testset "Test lq_drift_time_correction with Tail" begin
+
+    # Generate 10000 data points
+    N = 1000
+
+    # Generate dt_eff (drift time) with a Gaussian distribution
+    dt_mean = 500.0
+    dt_std = 100.0
+    dt_eff = (dt_mean .+ dt_std .* randn(N)) .* u"µs"
+
+    # Generate lq_norm with a linear dependence on dt_eff + some noise
+    true_slope = 0.001
+    true_intercept = 3
+    noise_level = 0.1
+    lq_norm = true_slope .* ustrip.(dt_eff) .+ true_intercept .+ randn(N) .* noise_level
+
+    # Introduce a tail for low drift times (below 350)
+    tail_threshold = 350.0
+    tail_factor = 0.1
+
+    lq_norm_tail = [lq + (tail_factor * (tail_threshold - dt)^2 / tail_threshold) * (dt < tail_threshold ? 1.0 : 0.0) for (lq, dt) in zip(lq_norm, ustrip.(dt_eff))]
+
+    # Generate energies at DEP
+    e_cal = 1600.0u"keV" .+ randn(N) .* 1.0u"keV"
+
+    # DEP parameters
+    DEP_µ = 1600.0u"keV"
+    DEP_σ = 1.0u"keV"
+
+    # Call the function with mode=:percentile
+    result, report = lq_drift_time_correction(lq_norm_tail, dt_eff, e_cal, DEP_µ, DEP_σ; mode=:percentile)
+
+    # Retrieve the fitted parameters
+    fitted_slope = report.drift_time_func(1.0) - report.drift_time_func(0.0)
+    fitted_intercept = report.drift_time_func(0.0)
+
+    # Check if the fitted slope and intercept match the true values (linear region)
+    @test isapprox(fitted_slope, true_slope, atol=0.0001)
+    @test isapprox(fitted_intercept, true_intercept, atol=0.1)
+end
+
+


### PR DESCRIPTION
Things generally changed in this pull request:
- aoe_cut.jl: renamed lq_mode to inverted mode and updated doc string
- lqcut.jl : fixed bugs from issue,  `lq_drift_time_correction `now works with mode instead of detector type, changed fitting form binned to unbinned for lq box fit during drift time correction, added percentile mode for drift time, added propfunc, updated result&report and doc strings, updated `LQ_cut `after bug fix in fitting, renamed some variables
- singlefit: fixed bug that where the bins of the truncated hist used for the fit where moved one bin to the left, resulting in the function beeing shifted to the left
- test: wrote test for LQ_cut and lq_drift_time_correction
- plots recipe: added recipe functions to plot report of `lq_drift_time_correction `and `LQ_cut`