### PR TITLE
Remove `maxtime` kwargs when calling `Optimization.LBFGS`

### DIFF
--- a/src/memory_utils.jl
+++ b/src/memory_utils.jl
@@ -1,6 +1,6 @@
 
-optim_max_mem=10.0 # in GB for the whole current process ignoring if things could run in parallel
-optim_time_limit=20.0 # in seconds a single Optim.jl optimization step
+const optim_max_mem=10.0 # in GB for the whole current process ignoring if things could run in parallel
+const optim_time_limit=20.0 # in seconds a single Optim.jl optimization step
 
 """
     set_memlimit(gig::Float64)

--- a/src/specfit.jl
+++ b/src/specfit.jl
@@ -98,7 +98,7 @@ function fit_single_peak_th228(h::Histogram, ps::NamedTuple{(:peak_pos, :peak_fw
     # MLE
     optf = OptimizationFunction((u, p) -> ((-) ∘ f_loglike ∘ inverse(f_trafo))(u), AutoForwardDiff())
     optpro = OptimizationProblem(optf, v_init, [])
-    res = solve(optpro, Optimization.LBFGS(), maxiters = 3000, maxtime=optim_time_limit)
+    res = solve(optpro, Optimization.LBFGS(), maxiters = 3000) #, maxtime=optim_time_limit)
 
     converged = (res.retcode == ReturnCode.Success)
     if !converged @warn "Fit did not converge" end
@@ -302,7 +302,7 @@ function fit_subpeaks_th228(
     # MLE
     optf = OptimizationFunction((u, p) -> ((-) ∘ f_loglike ∘ inverse(f_trafo))(u), AutoForwardDiff())
     optpro = OptimizationProblem(optf, v_init, [])
-    res = solve(optpro, Optimization.LBFGS(), maxiters = 3000, maxtime=optim_time_limit)
+    res = solve(optpro, Optimization.LBFGS(), maxiters = 3000) #, maxtime=optim_time_limit)
 
     converged = (res.retcode == ReturnCode.Success)
     if !converged @warn "Fit did not converge" end


### PR DESCRIPTION
I spotted a small copy/paste typo in the kwargs handling of LBFGS-B in Optimzation:
When checking if `maxtime` is set, it returns that `abstol` is not used. I assume it should read `maxtime` is not used: https://github.com/SciML/Optimization.jl/blob/5cb17b6b61bedc92295dd8b2f607ab6fcbbc0db7/src/lbfgsb.jl#L47-L49
To omit the tons of warnings, I removed `maxtime` everywhere where `LBFGS` is used as solver (because it is not used anyhow).