### PR TITLE
Increase the number of samples in `singlefit` tests

### DIFF
--- a/src/aoefit.jl
+++ b/src/aoefit.jl
@@ -180,7 +180,7 @@ function fit_single_aoe_compton(h::Histogram, ps::NamedTuple; uncertainty::Bool=
     # MLE
     optf = OptimizationFunction((u, p) -> ((-) ∘ f_loglike ∘ inverse(f_trafo))(u), AutoForwardDiff())
     optpro = OptimizationProblem(optf, v_init, [])
-    res = solve(optpro, Optimization.LBFGS(), maxiters = 3000, maxtime=optim_time_limit)
+    res = solve(optpro, Optimization.LBFGS(), maxiters = 3000) #, maxtime=optim_time_limit)
 
     converged = (res.retcode == ReturnCode.Success)
     if !converged @warn "Fit did not converge" end

--- a/src/aoefit_combined.jl
+++ b/src/aoefit_combined.jl
@@ -32,7 +32,7 @@ function fit_single_aoe_compton_with_fixed_μ_and_σ(h::Histogram, μ::Number, �
     # MLE
     optf = OptimizationFunction((u, p) -> ((-) ∘ f_loglike ∘ inverse(f_trafo))(u), AutoForwardDiff())
     optpro = OptimizationProblem(optf, v_init, [])
-    res = solve(optpro, Optimization.LBFGS(), maxiters = 3000, maxtime=optim_time_limit)
+    res = solve(optpro, Optimization.LBFGS(), maxiters = 3000)#, maxtime=optim_time_limit)
 
     converged = (res.retcode == ReturnCode.Success)
     if !converged @warn "Fit did not converge" end
@@ -129,7 +129,7 @@ function neg_log_likelihood_single_aoe_compton_with_fixed_μ_and_σ(h::Histogram
     if optimize
         optf = OptimizationFunction((u, p) -> ((-) ∘ f_loglike ∘ inverse(f_trafo))(u), AutoForwardDiff())
         optpro = OptimizationProblem(optf, v_init, [])
-        res = solve(optpro, Optimization.LBFGS(), maxiters = 3000, maxtime=optim_time_limit)
+        res = solve(optpro, Optimization.LBFGS(), maxiters = 3000)#, maxtime=optim_time_limit)
 
         converged = (res.retcode == ReturnCode.Success)
         if !converged @warn "Fit did not converge" end

--- a/src/lqfit.jl
+++ b/src/lqfit.jl
@@ -85,7 +85,7 @@ function fit_single_lq_compton(h::Histogram, ps::NamedTuple; uncertainty::Bool=t
     # MLE
     optf = OptimizationFunction((u, p) -> ((-) ∘ f_loglike ∘ inverse(f_trafo))(u), AutoForwardDiff())
     optpro = OptimizationProblem(optf, v_init, [])
-    res = solve(optpro, Optimization.LBFGS(), maxiters = 3000, maxtime=optim_time_limit)
+    res = solve(optpro, Optimization.LBFGS(), maxiters = 3000)#, maxtime=optim_time_limit)
 
     converged = (res.retcode == ReturnCode.Success)
     if !converged @warn "Fit did not converge" end

--- a/src/singlefit.jl
+++ b/src/singlefit.jl
@@ -52,7 +52,7 @@ function fit_single_trunc_gauss(x::Vector{<:Unitful.RealOrRealQuantity}, cuts::N
     # MLE
     optf = OptimizationFunction((u, p) -> (f_loglike ∘ inverse(f_trafo))(u), AutoForwardDiff())
     optpro = OptimizationProblem(optf, v_init, [])
-    res = solve(optpro, Optimization.LBFGS(), maxiters = 3000, maxtime=optim_time_limit)
+    res = solve(optpro, Optimization.LBFGS(), maxiters = 3000)#, maxtime=optim_time_limit)
 
     converged = (res.retcode == ReturnCode.Success)
     if !converged @warn "Fit did not converge" end
@@ -169,7 +169,7 @@ function fit_half_centered_trunc_gauss(x::Vector{<:Unitful.RealOrRealQuantity}, 
     # MLE
     optf = OptimizationFunction((u, p) -> (f_loglike ∘ inverse(f_trafo))(u), AutoForwardDiff())
     optpro = OptimizationProblem(optf, v_init, [])
-    res = solve(optpro, Optimization.LBFGS(), maxiters = 3000, maxtime=optim_time_limit)
+    res = solve(optpro, Optimization.LBFGS(), maxiters = 3000)#, maxtime=optim_time_limit)
 
     converged = (res.retcode == ReturnCode.Success)
     if !converged @warn "Fit did not converge" end
@@ -288,7 +288,7 @@ function fit_half_trunc_gauss(x::Vector{<:Unitful.RealOrRealQuantity}, cuts::Nam
     # MLE
     optf = OptimizationFunction((u, p) -> (f_loglike ∘ inverse(f_trafo))(u), AutoForwardDiff())
     optpro = OptimizationProblem(optf, v_init, [])
-    res = solve(optpro, Optimization.LBFGS(), maxiters = 3000, maxtime=optim_time_limit)
+    res = solve(optpro, Optimization.LBFGS(), maxiters = 3000)#, maxtime=optim_time_limit)
 
     converged = (res.retcode == ReturnCode.Success)
     if !converged @warn "Fit did not converge" end
@@ -418,7 +418,7 @@ function fit_binned_trunc_gauss(h_nocut::Histogram, cuts::NamedTuple{(:low, :hig
     # MLE
     optf = OptimizationFunction((u, p) -> ((-) ∘ f_loglike ∘ inverse(f_trafo))(u), AutoForwardDiff())
     optpro = OptimizationProblem(optf, v_init, [])
-    res = solve(optpro, Optimization.LBFGS(), maxiters = 3000, maxtime=optim_time_limit)
+    res = solve(optpro, Optimization.LBFGS(), maxiters = 3000)#, maxtime=optim_time_limit)
 
     converged = (res.retcode == ReturnCode.Success)
     if !converged @warn "Fit did not converge" end
@@ -524,7 +524,7 @@ function fit_binned_double_gauss(h::Histogram, ps::NamedTuple; uncertainty::Bool
     # MLE
     optf = OptimizationFunction((u, p) -> ((-) ∘ f_loglike ∘ inverse(f_trafo))(u), AutoForwardDiff())
     optpro = OptimizationProblem(optf, v_init, [])
-    res = solve(optpro, Optimization.LBFGS(), maxiters = 3000, maxtime=optim_time_limit)
+    res = solve(optpro, Optimization.LBFGS(), maxiters = 3000)#, maxtime=optim_time_limit)
 
     converged = (res.retcode == ReturnCode.Success)
     if !converged @warn "Fit did not converge" end

--- a/test/test_singlefit.jl
+++ b/test/test_singlefit.jl
@@ -13,7 +13,7 @@ include("test_utils.jl")
 @testset "singlefit" begin
     # compose dummy data 
     dist = Normal(0.0, 1.0)
-    x = rand(dist, 100000)
+    x = rand(dist, 1000000)
     x_cut = cut_single_peak(x, -3.0, 3.0)
     
     # fit the data


### PR DESCRIPTION
This PR might close #82.

Fitting a half gauss to noisy data results in the tests being unreliable.
I increased the number of samples in the `singlefit` tests to decrease the variance in the fit results for `μ` and `σ`.

# Before this PR
The fit values for `μ` would easily be something like `0.06` or `-0.06`, such that the frequency with which they would exceed the `abstol` of `0.1` would be reached often enough for the tests to fail.
![image](https://github.com/user-attachments/assets/20bccbb4-3735-47e7-8f69-8775e07be3ce)
![image](https://github.com/user-attachments/assets/95cf6a60-e048-497d-b499-be4436d6e807)

# After this PR
The variance of `μ` seems to be below `0.02`, such that the defined `abstol` of `0.1` is big enough to cover it.
However, it might still occur that the tests **rarely** fail
![image](https://github.com/user-attachments/assets/7317d769-8485-4959-b1c3-1ed1e671db5c)
![image](https://github.com/user-attachments/assets/963dca6e-ae3b-499c-9bcb-f4385980e128)
