### PR TITLE
Bug fix SiPM calibration

### DIFF
--- a/src/sipmfit.jl
+++ b/src/sipmfit.jl
@@ -103,8 +103,12 @@ function fit_sipm_spectrum(pe_cal::Vector{<:Real}, min_pe::Real=0.5, max_pe::Rea
     end
 
     # get pe_pos
-    get_pe_pos = pe -> dot(μ[in.(μ, (-Δpe_peak_assignment..Δpe_peak_assignment) .+ pe)], w[in.(μ, (-Δpe_peak_assignment..Δpe_peak_assignment) .+ pe)] ) / sum(w[in.(μ, (-Δpe_peak_assignment..Δpe_peak_assignment) .+ pe)])
-    get_pe_res = pe -> dot(σ[in.(μ, (-Δpe_peak_assignment..Δpe_peak_assignment) .+ pe)], w[in.(μ, (-Δpe_peak_assignment..Δpe_peak_assignment) .+ pe)] ) / sum(w[in.(μ, (-Δpe_peak_assignment..Δpe_peak_assignment) .+ pe)])
+    get_pe_pos = pe -> let sel = in.(μ, (-Δpe_peak_assignment..Δpe_peak_assignment) .+ pe)
+        dot(view(μ,sel), view(w,sel)) / sum(view(w,sel))
+    end
+    get_pe_res = pe -> let sel = in.(μ, (-Δpe_peak_assignment..Δpe_peak_assignment) .+ pe)
+        dot(view(σ,sel), view(w,sel)) / sum(view(w,sel))
+    end 
     n_pos_mixtures = [count(in.(μ, (-Δpe_peak_assignment..Δpe_peak_assignment) .+ pe)) for pe in pes]
 
     pe_pos = get_pe_pos.(pes)

--- a/src/sipmfit.jl
+++ b/src/sipmfit.jl
@@ -104,9 +104,11 @@ function fit_sipm_spectrum(pe_cal::Vector{<:Real}, min_pe::Real=0.5, max_pe::Rea
 
     # get pe_pos
     get_pe_pos = pe -> dot(μ[in.(μ, (-Δpe_peak_assignment..Δpe_peak_assignment) .+ pe)], w[in.(μ, (-Δpe_peak_assignment..Δpe_peak_assignment) .+ pe)] ) / sum(w[in.(μ, (-Δpe_peak_assignment..Δpe_peak_assignment) .+ pe)])
+    get_pe_res = pe -> dot(σ[in.(μ, (-Δpe_peak_assignment..Δpe_peak_assignment) .+ pe)], w[in.(μ, (-Δpe_peak_assignment..Δpe_peak_assignment) .+ pe)] ) / sum(w[in.(μ, (-Δpe_peak_assignment..Δpe_peak_assignment) .+ pe)])
     n_pos_mixtures = [count(in.(μ, (-Δpe_peak_assignment..Δpe_peak_assignment) .+ pe)) for pe in pes]
 
     pe_pos = get_pe_pos.(pes)
+    pe_res = get_pe_res.(pes)
 
     # create return histogram for report
     h_cal = fit(Histogram, pe_cal, ifelse(min_pe >= 0.5, min_pe-0.5, min_pe):bin_width:max_pe+0.5)
@@ -120,6 +122,8 @@ function fit_sipm_spectrum(pe_cal::Vector{<:Real}, min_pe::Real=0.5, max_pe::Rea
         peaks = pes,
         positions_cal = pe_pos,
         positions = f_uncal.(pe_pos),
+        resolutions_cal = pe_res,
+        resolutions = f_uncal.(pe_res) .- f_uncal(0.0),
         gof = gof
     )
     report = (

--- a/src/sipmfit.jl
+++ b/src/sipmfit.jl
@@ -34,7 +34,7 @@ function fit_sipm_spectrum(pe_cal::Vector{<:Real}, min_pe::Real=0.5, max_pe::Rea
     dmat = reshape(amps_fit, length(amps_fit), 1)
 
     # set up mixture model with given number of mixtures
-    gmm = GMM(n_mixtures, dmat; method=method, nInit=nInit, nIter=nIter, kind=kind)
+    gmm = GMM(n_mixtures, dmat; method=method, nInit=nInit, nIter=nIter, kind=kind, parallel=false)
     
     # get mixture model out of EM best fit estimate
     gmm_dist = MixtureModel(gmm)


### PR DESCRIPTION
- Deactived parallel processing in `GaussianMixtures` --> Require this [PR](https://github.com/davidavdav/GaussianMixtures.jl/pull/114) to be merged
- Include peak resolutions in output result