### PR TITLE
Deprecate functions: `surrival` --> `survival`

### DIFF
--- a/ext/LegendSpecFitsRecipesBaseExt.jl
+++ b/ext/LegendSpecFitsRecipesBaseExt.jl
@@ -127,7 +127,7 @@ end
 
 @recipe function f(report:: NamedTuple{(:wl, :min_sf, :a_grid_wl_sg, :sfs)})
     xlabel := "Window Length ($(unit(first(report.a_grid_wl_sg))))"
-    ylabel := "SEP Surrival Fraction ($(unit(first(report.sfs))))"
+    ylabel := "SEP Survival Fraction ($(unit(first(report.sfs))))"
     grid := :true
     gridcolor := :black
     gridalpha := 0.2

--- a/src/aoe_filter_optimization.jl
+++ b/src/aoe_filter_optimization.jl
@@ -83,7 +83,7 @@ function fit_sf_wl(e_dep::Vector{<:Real}, aoe_dep::ArrayOfSimilarArrays{<:Real},
             aoe_sep_i = flatview(aoe_sep)[i_aoe, :][isfinite.(flatview(aoe_sep)[i_aoe, :])] ./ result_sep.m_calib
             e_sep_i   = e_sep_calib[isfinite.(flatview(aoe_sep)[i_aoe, :])]
 
-            result_sep_sf, _ = get_peak_surrival_fraction(aoe_sep_i, e_sep_i, sep, sep_window, psd_cut.lowcut; uncertainty=uncertainty, fit_func=sep_cut_search_fit_func)
+            result_sep_sf, _ = get_peak_survival_fraction(aoe_sep_i, e_sep_i, sep, sep_window, psd_cut.lowcut; uncertainty=uncertainty, fit_func=sep_cut_search_fit_func)
 
             sep_sfs[i_aoe] = result_sep_sf.sf
             wls[i_aoe] = wl
@@ -98,7 +98,7 @@ function fit_sf_wl(e_dep::Vector{<:Real}, aoe_dep::ArrayOfSimilarArrays{<:Real},
     sep_sfs = sep_sfs[fts_success]
     wls = wls[fts_success]
 
-    # get minimal surrival fraction and window length
+    # get minimal survival fraction and window length
     sep_sfs_cut = 1.0u"percent" .< sep_sfs .< 100u"percent"
     if isempty(sep_sfs[sep_sfs_cut])
         @error "No valid SEP SF found"

--- a/src/qc.jl
+++ b/src/qc.jl
@@ -10,15 +10,15 @@ function baseline_qc(data::Q, qc_config::PropDict) where Q<:Table
     # get bl mean cut
     result_blmean, report_blmean = get_centered_gaussian_window_cut(data.blmean, qc_config.blmean.min, qc_config.blmean.max, qc_config.blmean.sigma, ; n_bins_cut=convert(Int64, round(length(data) * qc_config.blmean.n_bins_fraction)), relative_cut=qc_config.blmean.relative_cut, fixed_center=false, left=true)
     blmean_qc = result_blmean.low_cut .< data.blmean .< result_blmean.high_cut
-    @debug format("Baseline Mean cut surrival fraction {:.2f}%", count(blmean_qc) / length(data) * 100)
+    @debug format("Baseline Mean cut survival fraction {:.2f}%", count(blmean_qc) / length(data) * 100)
     # get bl slope cut
     result_blslope, report_blslope = get_centered_gaussian_window_cut(data.blslope, qc_config.blslope.min, qc_config.blslope.max, qc_config.blslope.sigma, ; n_bins_cut=convert(Int64, round(length(data) * qc_config.blslope.n_bins_fraction)), relative_cut=qc_config.blslope.relative_cut, fixed_center=true, left=false, center=zero(data.blslope[1]))
     blslope_qc = result_blslope.low_cut .< data.blslope .< result_blslope.high_cut
-    @debug format("Baseline Slope cut surrival fraction {:.2f}%", count(blslope_qc) / length(data) * 100)
+    @debug format("Baseline Slope cut survival fraction {:.2f}%", count(blslope_qc) / length(data) * 100)
     # get blsigma cut
     result_blsigma, report_blsigma = get_centered_gaussian_window_cut(data.blsigma, qc_config.blsigma.min, qc_config.blsigma.max, qc_config.blsigma.sigma, ; n_bins_cut=convert(Int64, round(length(data) * qc_config.blsigma.n_bins_fraction)), relative_cut=qc_config.blsigma.relative_cut, fixed_center=false, left=true)
     blsigma_qc = result_blsigma.low_cut .< data.blsigma .< result_blsigma.high_cut
-    @debug format("Baseline Sigma cut surrival fraction {:.2f}%", count(blsigma_qc) / length(data) * 100)
+    @debug format("Baseline Sigma cut survival fraction {:.2f}%", count(blsigma_qc) / length(data) * 100)
     
     result = (blmean = result_blmean, blslope = result_blslope, blsigma = result_blsigma)
     report = (blmean = report_blmean, blslope = report_blslope, blsigma = report_blsigma)


### PR DESCRIPTION
Let's remove a legacy typo that has been used in quite some places in `LegendSpecFits`:
some methods were named `surrival` instead of `survival`. This PR deprecates the method with `surrival` in their name and renames them to `survival`.

Calling the old methods should still work (and the functions are still exported), but they should be removed with the next breaking release.