### PR TITLE
adjust energy calibration to uncertainties in literature values

### DIFF
--- a/src/simple_calibration.jl
+++ b/src/simple_calibration.jl
@@ -100,8 +100,7 @@ function get_peakhists_th228(e::Vector{<:Unitful.Energy{<:Real}}, th228_lines::V
     # get histograms around calibration lines and peakstats
     peakenergies = [ustrip.(e_unit, filter(in(peak - first(window)..peak + last(window)), e)) for (peak, window) in zip(th228_lines, window_sizes)]
     peakstats = StructArray(estimate_single_peak_stats.(peakenergies, ustrip.(e_unit, bin_widths)))
-    peakhists = [fit(Histogram, ustrip.(e_unit, e), ustrip(e_unit, peak - first(window)):ps.bin_width:ustrip(e_unit, peak + last(window))) for (peak, window, ps) in zip(th228_lines, window_sizes, peakstats)]
-
+    peakhists = [fit(Histogram, ustrip.(e_unit, e), ustrip(e_unit, peak - first(window)):ps.bin_width:ustrip(e_unit, peak + last(window))) for (peak, window, ps) in zip(Measurements.value.(th228_lines), window_sizes, peakstats)]
     peakhists, peakstats, h, peakstats.bin_width .* e_unit
 end
 export get_peakhists_th228


### PR DESCRIPTION
Reason for change:`th228_lines` will have uncertainty values after the upcoming change in legend-metadata. 

I changed the simple calibration so that it can handle these uncertainties. The other functions involved in the energy calibration worked as is. 
