### PR TITLE
σ Plot Label Changes in Reports

### DIFF
--- a/src/LegendSpecFits.jl
+++ b/src/LegendSpecFits.jl
@@ -23,6 +23,7 @@ using GaussianMixtures
 using IntervalSets
 using InverseFunctions
 using IrrationalConstants
+using LaTeXStrings
 using LogExpFunctions
 using LsqFit
 using Measurements

--- a/src/aoe_fit_calibration.jl
+++ b/src/aoe_fit_calibration.jl
@@ -37,8 +37,8 @@ function fit_aoe_corrections(e::Array{<:Unitful.Energy{<:Real}}, μ::Array{<:Rea
     func_σ = "sqrt( ($(mvalue(result_σ.par[1])))^2 + ($(mvalue(result_σ.par[2]))$(e_unit))^2 / ($e_expression)^2 )" 
 
     result_σ = merge(result_σ, (par = par_σ, func = func_σ, σ = σ))
-    report_σ = merge(report_σ, (e_unit = e_unit, label_y = "σ", label_fit = "Best fit: sqrt(($(round(mvalue(result_σ.par[1])*1e6, digits=1))e-6)^2 + $(round(ustrip(mvalue(result_σ.par[2])), digits=2))^2 / E^2)"))
-    #report_σ = merge(report_σ, (e_unit = e_unit, label_y = "σ", label_fit = "Best fit: sqrt(($(round(mvalue(result_σ.par[1])*1e3, digits=2))e-3)^2 + $(round(ustrip(mvalue(result_σ.par[2])), digits=2))^2 / E^2)"))
+    report_σ = merge(report_σ, (e_unit = e_unit, label_y = "σ", label_fit = "Best Fit: sqrt(($(round(mvalue(result_σ.par[1])*1e6, digits=1))e-6)^2 + $(round(ustrip(mvalue(result_σ.par[2])), digits=2))^2 / E^2)"))
+    #report_σ = merge(report_σ, (e_unit = e_unit, label_y = "σ", label_fit = "Best Fit: sqrt(($(round(mvalue(result_σ.par[1])*1e3, digits=2))e-3)^2 + $(round(ustrip(mvalue(result_σ.par[2])), digits=2))^2 / E^2)"))
     @debug "Compton band σ normalization: $(result_σ.func)"
 
     # put everything together into A/E correction/normalization function 

--- a/src/aoe_fit_calibration.jl
+++ b/src/aoe_fit_calibration.jl
@@ -28,7 +28,7 @@ function fit_aoe_corrections(e::Array{<:Unitful.Energy{<:Real}}, μ::Array{<:Rea
     func_µ = "$(mvalue(result_µ.par[1])) + ($e_expression) * $(mvalue(result_µ.par[2]))$e_unit^-1"
     par_µ = [result_µ.par[i] ./ e_unit^(i-1) for i=1:length(result_µ.par)] # add units
     result_µ = merge(result_µ, (par = par_µ, func = func_µ, µ = µ)) 
-    report_µ = merge(report_µ, (e_unit = e_unit, label_y = "µ", label_fit = "Best Fit: $(mvalue(round(result_µ.par[1], digits=2))) + E * $(mvalue(round(ustrip(result_µ.par[2]) * 1e6, digits=2)))1e-6"))
+    report_µ = merge(report_µ, (e_unit = e_unit, label_y = "µ", label_fit = latexstring("Best Fit: \$ $(mvalue(round(result_µ.par[1], digits=2))) $(mvalue(ustrip(result_µ.par[2])) >= 0 ? "+" : "") $(mvalue(round(ustrip(result_µ.par[2]) * 1e6, digits=2)))\\cdot 10^{-6} \\; E \$")))
     @debug "Compton band µ correction: $(result_µ.func)"
 
     # fit compton band σ with sqrt function
@@ -37,7 +37,7 @@ function fit_aoe_corrections(e::Array{<:Unitful.Energy{<:Real}}, μ::Array{<:Rea
     func_σ = "sqrt( ($(mvalue(result_σ.par[1])))^2 + ($(mvalue(result_σ.par[2]))$(e_unit))^2 / ($e_expression)^2 )" 
 
     result_σ = merge(result_σ, (par = par_σ, func = func_σ, σ = σ))
-    report_σ = merge(report_σ, (e_unit = e_unit, label_y = "σ", label_fit = "Best Fit: sqrt(($(round(mvalue(result_σ.par[1])*1e6, digits=1))e-6)^2 + $(round(ustrip(mvalue(result_σ.par[2])), digits=2))^2 / E^2)"))
+    report_σ = merge(report_σ, (e_unit = e_unit, label_y = "σ", label_fit = latexstring("Best Fit: \$\\sqrt{($(abs(round(mvalue(result_σ.par[1])*1e3, digits=2)))\\cdot10^{-3})^2 + $(abs(round(ustrip(mvalue(result_σ.par[2])), digits=2)))^2 / E^2}\$")))
     #report_σ = merge(report_σ, (e_unit = e_unit, label_y = "σ", label_fit = "Best Fit: sqrt(($(round(mvalue(result_σ.par[1])*1e3, digits=2))e-3)^2 + $(round(ustrip(mvalue(result_σ.par[2])), digits=2))^2 / E^2)"))
     @debug "Compton band σ normalization: $(result_σ.func)"
 

--- a/src/aoe_fit_calibration.jl
+++ b/src/aoe_fit_calibration.jl
@@ -38,7 +38,7 @@ function fit_aoe_corrections(e::Array{<:Unitful.Energy{<:Real}}, μ::Array{<:Rea
 
     result_σ = merge(result_σ, (par = par_σ, func = func_σ, σ = σ))
     report_σ = merge(report_σ, (e_unit = e_unit, label_y = "σ", label_fit = "Best fit: sqrt(($(round(mvalue(result_σ.par[1])*1e6, digits=1))e-6)^2 + $(round(ustrip(mvalue(result_σ.par[2])), digits=2))^2 / E^2)"))
-    #report_σ = merge(report_σ, (e_unit = e_unit, label_y = "σ", label_fit = "Best fit: sqrt(($(round(mvalue(result_σ.par[1])*1e3, digits=1))e-3)^2 + $(round(ustrip(mvalue(result_σ.par[2])), digits=2))^2 / E^2)"))
+    #report_σ = merge(report_σ, (e_unit = e_unit, label_y = "σ", label_fit = "Best fit: sqrt(($(round(mvalue(result_σ.par[1])*1e3, digits=2))e-3)^2 + $(round(ustrip(mvalue(result_σ.par[2])), digits=2))^2 / E^2)"))
     @debug "Compton band σ normalization: $(result_σ.func)"
 
     # put everything together into A/E correction/normalization function 

--- a/src/aoe_fit_calibration.jl
+++ b/src/aoe_fit_calibration.jl
@@ -37,7 +37,8 @@ function fit_aoe_corrections(e::Array{<:Unitful.Energy{<:Real}}, μ::Array{<:Rea
     func_σ = "sqrt( ($(mvalue(result_σ.par[1])))^2 + ($(mvalue(result_σ.par[2]))$(e_unit))^2 / ($e_expression)^2 )" 
 
     result_σ = merge(result_σ, (par = par_σ, func = func_σ, σ = σ))
-    report_σ = merge(report_σ, (e_unit = e_unit, label_y = "σ", label_fit = "Best fit: sqrt($(round(mvalue(result_σ.par[1])*1e6, digits=1))e-6 + $(round(ustrip(mvalue(result_σ.par[2])), digits=2)) / E^2)"))
+    report_σ = merge(report_σ, (e_unit = e_unit, label_y = "σ", label_fit = "Best fit: sqrt(($(round(mvalue(result_σ.par[1])*1e6, digits=1))e-6)^2 + $(round(ustrip(mvalue(result_σ.par[2])), digits=2))^2 / E^2)"))
+    #report_σ = merge(report_σ, (e_unit = e_unit, label_y = "σ", label_fit = "Best fit: sqrt(($(round(mvalue(result_σ.par[1])*1e3, digits=1))e-3)^2 + $(round(ustrip(mvalue(result_σ.par[2])), digits=2))^2 / E^2)"))
     @debug "Compton band σ normalization: $(result_σ.func)"
 
     # put everything together into A/E correction/normalization function 

--- a/src/aoefit_combined.jl
+++ b/src/aoefit_combined.jl
@@ -349,8 +349,10 @@ function fit_aoe_compton_combined(peakhists::Vector{<:Histogram}, peakstats::Str
     result = merge(result, (µ_compton = result_µ, σ_compton = result_σ, compton_bands = (e = es,), func = func_aoe_corr))
 
     # Create report for plotting the combined fit results
-    label_fit_µ = "Combined Fit: $(round(mvalue(v_ml.μA), digits=2)) + E * $(round(mvalue(v_ml.μB)*1e6, digits=2))e-6"
-    label_fit_σ = "Combined Fit: sqrt(($(round(mvalue(v_ml.σA)*1e6, digits=1))e-6)^2 + $(round(ustrip(mvalue(v_ml.σB)), digits=2))^2 / E^2)"
+    label_fit_µ = latexstring("Combined Fit: \$ $(round(mvalue(v_ml.μA), digits=2)) $(mvalue(v_ml.μB) >= 0 ? "+" : "") $(round(mvalue(v_ml.μB)*1e6, digits=2))\\cdot 10^{-6} \\; E \$")
+    label_fit_σ = latexstring("Combined Fit: \$\\sqrt{($(abs(round(mvalue(v_ml.σA)*1e3, digits=2)))\\cdot10^{-3})^2 + $(abs(round(ustrip(mvalue(v_ml.σB)), digits=2)))^2 / E^2}\$")
+    #label_fit_µ = "Combined Fit:  + E * $(round(mvalue(v_ml.μB)*1e6, digits=2))e-6"
+    #label_fit_σ = "Combined Fit: sqrt(($(round(mvalue(v_ml.σA)*1e6, digits=1))e-6)^2 + $(round(ustrip(mvalue(v_ml.σB)), digits=2))^2 / E^2)"
     #label_fit_σ = "Combined Fit: sqrt(($(round(mvalue(v_ml.σA)*1e3, digits=2))e-3)^2 + $(round(ustrip(mvalue(v_ml.σB)), digits=2))^2 / E^2)"
     
     μ_values = f_aoe_mu(es, (v_ml.μA, v_ml.μB))

--- a/src/aoefit_combined.jl
+++ b/src/aoefit_combined.jl
@@ -350,7 +350,8 @@ function fit_aoe_compton_combined(peakhists::Vector{<:Histogram}, peakstats::Str
 
     # Create report for plotting the combined fit results
     label_fit_µ = "Combined Fit: $(round(mvalue(v_ml.μA), digits=2)) + E * $(round(mvalue(v_ml.μB)*1e6, digits=2))e-6"
-    label_fit_σ = "Combined Fit: sqrt($(round(mvalue(v_ml.σA)*1e6, digits=1))e-6 + $(round(ustrip(mvalue(v_ml.σB)), digits=2)) / E^2)"
+    label_fit_σ = "Combined Fit: sqrt(($(round(mvalue(v_ml.σA)*1e6, digits=1))e-6)^2 + $(round(ustrip(mvalue(v_ml.σB)), digits=2))^2 / E^2)"
+    #label_fit_σ = "Combined Fit: sqrt(($(round(mvalue(v_ml.σA)*1e3, digits=1))e-3)^2 + $(round(ustrip(mvalue(v_ml.σB)), digits=2))^2 / E^2)"
     
     μ_values = f_aoe_mu(es, (v_ml.μA, v_ml.μB))
     σ_values = f_aoe_sigma(es, (v_ml.σA, v_ml.σB))

--- a/src/aoefit_combined.jl
+++ b/src/aoefit_combined.jl
@@ -351,7 +351,7 @@ function fit_aoe_compton_combined(peakhists::Vector{<:Histogram}, peakstats::Str
     # Create report for plotting the combined fit results
     label_fit_µ = "Combined Fit: $(round(mvalue(v_ml.μA), digits=2)) + E * $(round(mvalue(v_ml.μB)*1e6, digits=2))e-6"
     label_fit_σ = "Combined Fit: sqrt(($(round(mvalue(v_ml.σA)*1e6, digits=1))e-6)^2 + $(round(ustrip(mvalue(v_ml.σB)), digits=2))^2 / E^2)"
-    #label_fit_σ = "Combined Fit: sqrt(($(round(mvalue(v_ml.σA)*1e3, digits=1))e-3)^2 + $(round(ustrip(mvalue(v_ml.σB)), digits=2))^2 / E^2)"
+    #label_fit_σ = "Combined Fit: sqrt(($(round(mvalue(v_ml.σA)*1e3, digits=2))e-3)^2 + $(round(ustrip(mvalue(v_ml.σB)), digits=2))^2 / E^2)"
     
     μ_values = f_aoe_mu(es, (v_ml.μA, v_ml.μB))
     σ_values = f_aoe_sigma(es, (v_ml.σA, v_ml.σB))


### PR DESCRIPTION
- Squares added to the labels in the σ plot (parameters of the fit are squared under the square root, which has been implemented in the code but is not yet shown in the labels) in the reports of the functions `fit_aoe_corrections` and `fit_aoe_compton_combined`

- Choose between labels where the first fit parameter is multiplied by e6 or by e3 (the label e3 is commented out)