### PR TITLE
Remove filtering of `µ` and `σ` in the (individual) A/E correction fit

### DIFF
--- a/src/aoe_fit_calibration.jl
+++ b/src/aoe_fit_calibration.jl
@@ -14,10 +14,10 @@ Fit the corrections for the AoE value of the detector.
 - `f_σ_scs`: Fit function for the sigma values
 """
 function fit_aoe_corrections(e::Array{<:Unitful.Energy{<:Real}}, μ::Array{<:Real}, σ::Array{<:Real}; aoe_expression::Union{String,Symbol}="a / e", e_expression::Union{String,Symbol}="e")
-    # fit compton band mus with linear function
-    μ_cut = (mean(μ) - 2*std(μ) .< μ .< mean(μ) + 2*std(μ)) .&& muncert.(μ) .> 0.0
+
+    μ_cut = muncert.(μ) .> 0.0
     e, μ, σ = e[μ_cut], μ[μ_cut], σ[μ_cut]
-    σ_cut = (mean(σ) - std(σ) .< σ .< mean(σ) + std(σ)) .&& muncert.(σ) .> 0.0
+    σ_cut = muncert.(σ) .> 0.0
     e_unit = unit(first(e))
     e = ustrip.(e_unit, e)
     


### PR DESCRIPTION
In `fit_aoe_corrections`, the values of `µ` and `σ` were filtered by some sigma cut to remove outliers. However, this resulted in some "good" values for `µ` and `σ` at low energies to be removed.
I propose to remove this filter and accept the risk of individual outliers.

This only affects the individual A/E fits. The combined fit routine does not prefilter the values of `µ` and `σ`. This might also explain the observed differences between individual and combined fit (because the individual fits just fitted less data points).

### Before this PR
![image](https://github.com/user-attachments/assets/d1fe531a-4aff-4eaa-8ade-9b52d125242f)


### After this PR
![image (1)](https://github.com/user-attachments/assets/3a10de2b-3605-4c9d-9a42-148500942edb)

Note: the nice fit labels are composed with the changes in #115, so I would also vote for merging both PRs at the same time.
