### PR TITLE
Avoid deprecated methods

### DIFF
--- a/src/aoe_cut.jl
+++ b/src/aoe_cut.jl
@@ -9,8 +9,8 @@ Get the survival fraction after a AoE cut value `aoe_cut` for a given `peak` and
 """
 function get_sf_after_aoe_cut(aoe_cut::Unitful.RealOrRealQuantity, aoe::Vector{<:Unitful.RealOrRealQuantity}, e::Vector{<:T}, peak::T, window::Vector{T}, bin_width::T, result_before::NamedTuple; uncertainty::Bool=true, fit_func::Symbol=:gamma_def) where T<:Unitful.Energy{<:Real}
     # get energy after cut and create histogram
-    survived = fit(Histogram, ustrip.(e[aoe .>= aoe_cut]), ustrip(peak-first(window):bin_width:peak+last(window)))
-    cut = fit(Histogram, ustrip.(e[aoe .< aoe_cut]), ustrip(peak-first(window):bin_width:peak+last(window)))
+    survived = fit(Histogram, ustrip.(e[aoe .>= aoe_cut]), ustrip.(peak-first(window):bin_width:peak+last(window)))
+    cut = fit(Histogram, ustrip.(e[aoe .< aoe_cut]), ustrip.(peak-first(window):bin_width:peak+last(window)))
     # fit peak and return number of signal counts
     result, _ = fit_subpeaks_th228(survived, cut, result_before; uncertainty=uncertainty, fit_func=fit_func)
     return result.sf

--- a/src/aoefit.jl
+++ b/src/aoefit.jl
@@ -54,7 +54,7 @@ function generate_aoe_compton_bands(aoe::Vector{<:Real}, e::Vector{<:T}, compton
     simple_pars_aoe_μ       = simple_fit_aoe_μ.param
     simple_pars_error_aoe_μ = zeros(length(simple_pars_aoe_μ))
     try
-        simple_pars_error_aoe_μ = standard_errors(simple_fit_aoe_μ)
+        simple_pars_error_aoe_μ = stderror(simple_fit_aoe_μ)
     catch e
         @warn "Error calculating standard errors for simple fitted μ: $e"
     end
@@ -67,7 +67,7 @@ function generate_aoe_compton_bands(aoe::Vector{<:Real}, e::Vector{<:T}, compton
     simple_pars_aoe_σ       = simple_fit_aoe_σ.param
     simple_pars_error_aoe_σ = zeros(length(simple_pars_aoe_σ))
     try
-        simple_pars_error_aoe_σ = standard_errors(simple_fit_aoe_σ)
+        simple_pars_error_aoe_σ = stderror(simple_fit_aoe_σ)
     catch e
         @warn "Error calculating standard errors for simple fitted σ: $e"
     end


### PR DESCRIPTION
While running some tests, I got some warning about deprecated methods being used in LegendSpecFits, which we might wanna remove. This is done in this PR.

![image](https://github.com/user-attachments/assets/67f28628-5963-485d-bdcf-403569028b97)
