### PR TITLE
Omit performance warning when creating `OptimizationProblem`

### DIFF
--- a/src/aoe_ctc.jl
+++ b/src/aoe_ctc.jl
@@ -86,7 +86,7 @@ function ctc_aoe(aoe_all::Vector{<:Real}, ecal_all::Vector{<:Unitful.RealOrRealQ
 
     # optimization
     optf = OptimizationFunction((u, p) -> f_minimize(u), AutoForwardDiff())
-    optpro = OptimizationProblem(optf, fct_start, [], lb=fct_lb, ub=fct_ub)
+    optpro = OptimizationProblem(optf, fct_start, (), lb=fct_lb, ub=fct_ub)
     res = solve(optpro, NLopt.LN_BOBYQA(), maxiters = 3000, maxtime=optim_time_limit)
     converged = (res.retcode == ReturnCode.Success)
 

--- a/src/aoefit.jl
+++ b/src/aoefit.jl
@@ -179,7 +179,7 @@ function fit_single_aoe_compton(h::Histogram, ps::NamedTuple; uncertainty::Bool=
 
     # MLE
     optf = OptimizationFunction((u, p) -> ((-) ∘ f_loglike ∘ inverse(f_trafo))(u), AutoForwardDiff())
-    optpro = OptimizationProblem(optf, v_init, [])
+    optpro = OptimizationProblem(optf, v_init, ())
     res = solve(optpro, Optimization.LBFGS(), maxiters = 3000) #, maxtime=optim_time_limit)
 
     converged = (res.retcode == ReturnCode.Success)

--- a/src/aoefit_combined.jl
+++ b/src/aoefit_combined.jl
@@ -31,7 +31,7 @@ function fit_single_aoe_compton_with_fixed_μ_and_σ(h::Histogram, μ::Number, �
 
     # MLE
     optf = OptimizationFunction((u, p) -> ((-) ∘ f_loglike ∘ inverse(f_trafo))(u), AutoForwardDiff())
-    optpro = OptimizationProblem(optf, v_init, [])
+    optpro = OptimizationProblem(optf, v_init, ())
     res = solve(optpro, Optimization.LBFGS(), maxiters = 3000)#, maxtime=optim_time_limit)
 
     converged = (res.retcode == ReturnCode.Success)
@@ -128,7 +128,7 @@ function neg_log_likelihood_single_aoe_compton_with_fixed_μ_and_σ(h::Histogram
     # MLE
     if optimize
         optf = OptimizationFunction((u, p) -> ((-) ∘ f_loglike ∘ inverse(f_trafo))(u), AutoForwardDiff())
-        optpro = OptimizationProblem(optf, v_init, [])
+        optpro = OptimizationProblem(optf, v_init, ())
         res = solve(optpro, Optimization.LBFGS(), maxiters = 3000)#, maxtime=optim_time_limit)
 
         converged = (res.retcode == ReturnCode.Success)
@@ -202,7 +202,7 @@ function fit_aoe_compton_combined(peakhists::Vector{<:Histogram}, peakstats::Str
     
     # MLE
     optf = OptimizationFunction((u, p) -> (f_loglike ∘ inverse(f_trafo))(u), AutoForwardDiff())
-    optpro = OptimizationProblem(optf, v_init, [])
+    optpro = OptimizationProblem(optf, v_init, ())
     res = solve(optpro, NLopt.LN_BOBYQA(), maxiters = 5000, maxtime=5*optim_time_limit)
     converged = (res.retcode == ReturnCode.Success)
     if !converged @warn "Fit did not converge" end

--- a/src/chi2fit.jl
+++ b/src/chi2fit.jl
@@ -71,7 +71,7 @@ function chi2fit(f_fit::Function, x::AbstractVector{<:Union{Real,Measurement{<:R
 
     # minimization and error estimation
     optf = OptimizationFunction((u, p) -> (f_opt ∘ inverse(f_trafo))(u), AutoForwardDiff())
-    optprob = OptimizationProblem(optf, f_trafo(v_init), [], lb=lower_bound, ub=upper_bound)
+    optprob = OptimizationProblem(optf, f_trafo(v_init), (), lb=lower_bound, ub=upper_bound)
     res = solve(optprob, NLopt.LN_BOBYQA(), maxiters = 3000, maxtime=optim_time_limit)
     
     converged = (res.retcode == ReturnCode.Success)

--- a/src/ctc.jl
+++ b/src/ctc.jl
@@ -67,7 +67,7 @@ function ctc_energy(e::Vector{<:Unitful.Energy{<:Real}}, qdrift::Vector{<:Real},
 
     # optimization
     optf = OptimizationFunction((u, p) -> f_minimize(u), AutoForwardDiff())
-    optpro = OptimizationProblem(optf, ustrip.(e_unit, fct_start), [], lb=ustrip.(e_unit, fct_lb), ub=ustrip.(e_unit, fct_ub))
+    optpro = OptimizationProblem(optf, ustrip.(e_unit, fct_start), (), lb=ustrip.(e_unit, fct_lb), ub=ustrip.(e_unit, fct_ub))
     res = solve(optpro, NLopt.LN_BOBYQA(), maxiters = 3000, maxtime=optim_time_limit)
     converged = (res.retcode == ReturnCode.Success)
 

--- a/src/lqfit.jl
+++ b/src/lqfit.jl
@@ -84,7 +84,7 @@ function fit_single_lq_compton(h::Histogram, ps::NamedTuple; uncertainty::Bool=t
 
     # MLE
     optf = OptimizationFunction((u, p) -> ((-) ∘ f_loglike ∘ inverse(f_trafo))(u), AutoForwardDiff())
-    optpro = OptimizationProblem(optf, v_init, [])
+    optpro = OptimizationProblem(optf, v_init, ())
     res = solve(optpro, Optimization.LBFGS(), maxiters = 3000)#, maxtime=optim_time_limit)
 
     converged = (res.retcode == ReturnCode.Success)

--- a/src/singlefit.jl
+++ b/src/singlefit.jl
@@ -51,7 +51,7 @@ function fit_single_trunc_gauss(x::Vector{<:Unitful.RealOrRealQuantity}, cuts::N
 
     # MLE
     optf = OptimizationFunction((u, p) -> (f_loglike ∘ inverse(f_trafo))(u), AutoForwardDiff())
-    optpro = OptimizationProblem(optf, v_init, [])
+    optpro = OptimizationProblem(optf, v_init, ())
     res = solve(optpro, Optimization.LBFGS(), maxiters = 3000)#, maxtime=optim_time_limit)
 
     converged = (res.retcode == ReturnCode.Success)
@@ -170,7 +170,7 @@ function fit_half_centered_trunc_gauss(x::Vector{<:Unitful.RealOrRealQuantity}, 
 
     # MLE
     optf = OptimizationFunction((u, p) -> (f_loglike ∘ inverse(f_trafo))(u), AutoForwardDiff())
-    optpro = OptimizationProblem(optf, v_init, [])
+    optpro = OptimizationProblem(optf, v_init, ())
     res = solve(optpro, Optimization.LBFGS(), maxiters = 3000)#, maxtime=optim_time_limit)
 
     converged = (res.retcode == ReturnCode.Success)
@@ -291,7 +291,7 @@ function fit_half_trunc_gauss(x::Vector{<:Unitful.RealOrRealQuantity}, cuts::Nam
 
     # MLE
     optf = OptimizationFunction((u, p) -> (f_loglike ∘ inverse(f_trafo))(u), AutoForwardDiff())
-    optpro = OptimizationProblem(optf, v_init, [])
+    optpro = OptimizationProblem(optf, v_init, ())
     res = solve(optpro, Optimization.LBFGS(), maxiters = 3000)#, maxtime=optim_time_limit)
 
     converged = (res.retcode == ReturnCode.Success)
@@ -423,7 +423,7 @@ function fit_binned_trunc_gauss(h_nocut::Histogram, cuts::NamedTuple{(:low, :hig
 
     # MLE
     optf = OptimizationFunction((u, p) -> ((-) ∘ f_loglike ∘ inverse(f_trafo))(u), AutoForwardDiff())
-    optpro = OptimizationProblem(optf, v_init, [])
+    optpro = OptimizationProblem(optf, v_init, ())
     res = solve(optpro, Optimization.LBFGS(), maxiters = 3000)#, maxtime=optim_time_limit)
 
     converged = (res.retcode == ReturnCode.Success)
@@ -529,7 +529,7 @@ function fit_binned_double_gauss(h::Histogram, ps::NamedTuple; uncertainty::Bool
 
     # MLE
     optf = OptimizationFunction((u, p) -> ((-) ∘ f_loglike ∘ inverse(f_trafo))(u), AutoForwardDiff())
-    optpro = OptimizationProblem(optf, v_init, [])
+    optpro = OptimizationProblem(optf, v_init, ())
     res = solve(optpro, Optimization.LBFGS(), maxiters = 3000)#, maxtime=optim_time_limit)
 
     converged = (res.retcode == ReturnCode.Success)

--- a/src/specfit.jl
+++ b/src/specfit.jl
@@ -97,7 +97,7 @@ function fit_single_peak_th228(h::Histogram, ps::NamedTuple{(:peak_pos, :peak_fw
 
     # MLE
     optf = OptimizationFunction((u, p) -> ((-) ∘ f_loglike ∘ inverse(f_trafo))(u), AutoForwardDiff())
-    optpro = OptimizationProblem(optf, v_init, [])
+    optpro = OptimizationProblem(optf, v_init, ())
     res = solve(optpro, Optimization.LBFGS(), maxiters = 3000) #, maxtime=optim_time_limit)
 
     converged = (res.retcode == ReturnCode.Success)
@@ -301,7 +301,7 @@ function fit_subpeaks_th228(
 
     # MLE
     optf = OptimizationFunction((u, p) -> ((-) ∘ f_loglike ∘ inverse(f_trafo))(u), AutoForwardDiff())
-    optpro = OptimizationProblem(optf, v_init, [])
+    optpro = OptimizationProblem(optf, v_init, ())
     res = solve(optpro, Optimization.LBFGS(), maxiters = 3000) #, maxtime=optim_time_limit)
 
     converged = (res.retcode == ReturnCode.Success)


### PR DESCRIPTION
Tired of seeing this warning?
![image](https://github.com/user-attachments/assets/cdc5896b-8a62-4bef-86b2-73f1e655d914)

Say no more. We can replace `[]` by `()` (`Tuple` instead of `Vector`) to avoid this warning:
![image](https://github.com/user-attachments/assets/bb1de61e-cabe-41a7-acc0-4daf39a387fe)

This is done everywhere in `LegendSpecFits` in this PR.