### PR TITLE
updated LQ sideband selection logic

### DIFF
--- a/ext/LegendSpecFitsRecipesBaseExt.jl
+++ b/ext/LegendSpecFitsRecipesBaseExt.jl
@@ -1476,7 +1476,7 @@ end
 
 # recipe for the lq_cut report
 
-@recipe function f(report::NamedTuple{(:cut, :fit_result, :temp_hists, :fit_report)}, lq_class::Vector{Float64}, e_cal, plot_type::Symbol)
+@recipe function f(report::NamedTuple{(:cut, :fit_result, :temp_hists, :fit_report, :dep_σ, :edges)}, lq_class::Vector{Float64}, e_cal, plot_type::Symbol)
 
     # Extract cutvalue from the report
     cut_value = Measurements.value.(report.cut)
@@ -1662,10 +1662,40 @@ end
             report.temp_hists.hist_sb2
         end
 
-
+    elseif plot_type == :energy_spectrum
+        # Plot energy spectrum with DEP and sideband regions
+        left_margin := -2Plots.mm
+        bottom_margin := -4Plots.mm
+        top_margin := -3Plots.mm
+        thickness_scaling := 1.6
+        size := (1200, 900)
+        framestyle := :box
+        formatter := :plain
+        xlabel := "Energy"
+        ylabel := "Counts"
+        
+        @series begin
+            seriestype := :stephist
+            label := "Energy Spectrum (σ: $(report.dep_σ))"
+            bins := 1000
+            e_cal[1500u"keV" .< e_cal .< 1660u"keV"]
+        end
+    
+        @series begin
+            seriestype := :vline
+            label := "DEP Region"
+            fillcolor := :red
+            [report.edges.DEP_edge_left, report.edges.DEP_edge_right]
+        end
+    
+        @series begin
+            seriestype := :vline
+            label := "Sideband Edges"
+            fillcolor := :green
+            legend := :bottomright
+            [report.edges.sb1_edge, report.edges.sb2_edge]
+        end
     end
 end
-
-
 
 end # module LegendSpecFitsRecipesBaseExt

--- a/ext/LegendSpecFitsRecipesBaseExt.jl
+++ b/ext/LegendSpecFitsRecipesBaseExt.jl
@@ -1390,9 +1390,9 @@ end
     xlabel := "Drift Time"
     ylabel := "LQ (A.U.)"
     framestyle := :box
-    left_margin := -2Plots.mm
-    bottom_margin := -4Plots.mm
-    top_margin := -3Plots.mm
+    left_margin := (-2, :mm)
+    bottom_margin := (-4, :mm)
+    top_margin := (-3, :mm)
     color := :viridis
     formatter := :plain
     thickness_scaling := 1.6
@@ -1482,9 +1482,9 @@ end
     cut_value = Measurements.value.(report.cut)
 
     # Plot configuration for all types
-    left_margin := -2Plots.mm
-    bottom_margin := -4Plots.mm
-    top_margin := -3Plots.mm
+    left_margin := (-2, :mm)
+    bottom_margin := (-4, :mm)
+    top_margin := (-3, :mm)
     thickness_scaling := 1.6
     size := (1200, 900)
     framestyle := :box
@@ -1664,9 +1664,9 @@ end
 
     elseif plot_type == :energy_spectrum
         # Plot energy spectrum with DEP and sideband regions
-        left_margin := -2Plots.mm
-        bottom_margin := -4Plots.mm
-        top_margin := -3Plots.mm
+        left_margin := (-2, :mm)
+        bottom_margin := (-4, :mm)
+        top_margin := (-3, :mm)
         thickness_scaling := 1.6
         size := (1200, 900)
         framestyle := :box
@@ -1676,7 +1676,7 @@ end
         
         @series begin
             seriestype := :stephist
-            label := "Energy Spectrum (σ: $(report.dep_σ))"
+            label := "Energy Spectrum (σ: $(round(u"keV", report.dep_σ, sigdigits=3)))"
             bins := 1000
             e_cal[1500u"keV" .< e_cal .< 1660u"keV"]
         end
@@ -1692,7 +1692,7 @@ end
             seriestype := :vline
             label := "Sideband Edges"
             fillcolor := :green
-            legend := :bottomright
+            legend := :topleft
             [report.edges.sb1_edge, report.edges.sb2_edge]
         end
     end


### PR DESCRIPTION
This pull request changes how the LQ sideband are generated. Currently the peak is defined as 4.5 dep_sigma(value from calibration) around the literature value of the DEP. The sidebands lie between 4.5 and 9 sigma on both sides of the peak band. For Detectors with low resolution this can result in a case where the sidebands reach into the 212-Bi FEP. To avoid this, I moved the both sidebands to the energies below the DEP.

Plot of Detector with normal energy res:
![l200-part01-cal-B00076C-energy_spectrum_lq_classifier](https://github.com/user-attachments/assets/7099a5f7-aa17-405f-a94e-a0b5bfdacddf)


Plot of Detector with bad energy res before PR
![l200-part01-cal-V08682A-energy_spectrum_lq_classifier](https://github.com/user-attachments/assets/14d29931-fd61-4d2c-a996-42bd41239dab)

Plot of same Detector after PR
![sideband](https://github.com/user-attachments/assets/0ddc9fed-d548-4b84-8fcf-706198057b4c)

Also added with this PR is a recipe for the plot above, that can be implemented into the lq_processors
