### PR TITLE
Added missing bracket

### DIFF
--- a/src/lqcut.jl
+++ b/src/lqcut.jl
@@ -109,7 +109,7 @@ function lq_ctc_correction(
     pol_fit_func = report_µ.f_fit
 
     # property function for drift time correction
-    lq_class_func = "$lq_e_corr_expression - " * join(["$(par[i]) * $dt_eff_expression^$(i-1)" for i in eachindex(par)], " - ")
+    lq_class_func = "$lq_e_corr_expression - " * join(["($(par[i]) * $dt_eff_expression)^$(i-1)" for i in eachindex(par)], " - ")
     lq_class_func_generic = "lq / e  - (slope * qdrift / e + y_inter)"
 
     # create result and report

--- a/src/lqcut.jl
+++ b/src/lqcut.jl
@@ -109,7 +109,7 @@ function lq_ctc_correction(
     pol_fit_func = report_µ.f_fit
 
     # property function for drift time correction
-    lq_class_func = "$lq_e_corr_expression - " * join(["($(par[i]) * $dt_eff_expression)^$(i-1)" for i in eachindex(par)], " - ")
+    lq_class_func = "$lq_e_corr_expression - " * join(["$(par[i]) * ($dt_eff_expression)^$(i-1)" for i in eachindex(par)], " - ")
     lq_class_func_generic = "lq / e  - (slope * qdrift / e + y_inter)"
 
     # create result and report


### PR DESCRIPTION
Hi, I noticed that something strange was happening with the LQ processor. I noticed that the dirft time correction property function got broken during Florians debugging. Previoues to this PR the `lq_ctc_correction`() function expected the `ctc_driftime_expression` to have brackets. I now changed this so that the function also returns the correct property function if `ctc_driftime_expression` does not have explicitly brackets.

@theHenks  I also noticed that during your debugging you encountered some problems with my plots. This happened because the the wrong ctc correction broke them. With this fix they all work again as intended and it would suggest to include the `lq_cut` plot again as it is currently commented out. Except you had another reason the remove it from the lq processors 