### PR TITLE
Fix argument type of `fit_enc_sigmas`

### DIFF
--- a/src/filter_optimization.jl
+++ b/src/filter_optimization.jl
@@ -15,7 +15,7 @@ Fit the ENC values in `enc_grid` for each RT in `enc_grid_rt` with a Gaussian an
 - `rt`: optimal RT value
 - `min_enc`: corresponding ENC value
 """
-function fit_enc_sigmas(enc_grid::Matrix{T}, enc_grid_rt::StepRangeLen{Quantity{<:T}, Base.TwicePrecision{Quantity{<:T}}, Base.TwicePrecision{Quantity{<:T}}, Int64}, min_enc::T, max_enc::T, nbins::Int64, rel_cut_fit::T) where T<:Real
+function fit_enc_sigmas(enc_grid::Matrix{T}, enc_grid_rt::StepRangeLen{<:Quantity{<:T}, <:Base.TwicePrecision{<:Quantity{<:T}}, <:Base.TwicePrecision{<:Quantity{<:T}}, Int64}, min_enc::T, max_enc::T, nbins::Int64, rel_cut_fit::T) where T<:Real
     @assert size(enc_grid, 1) == length(enc_grid_rt) "enc_grid and enc_grid_rt must have the same number of columns"
     
     # create empty array for results


### PR DESCRIPTION
I tried to test this `fit_enc_sigmas` by passing the second argument as `(1.0:1.0:20.0)u"µs"`, but it failed.. this little change in the type of the argument type seems to fix it.