### PR TITLE
Require `peakfinder_σ_scaled` in `sipm_simple_calibration` to be an integer

### DIFF
--- a/src/sipm_simple_calibration.jl
+++ b/src/sipm_simple_calibration.jl
@@ -49,7 +49,8 @@ function sipm_simple_calibration(pe_uncal::Vector{<:Real};
         peakfinder_σ_scaled = if peakfinder_σ <= 0.0
             round(Int, 2*(cuts_1pe.high - cuts_1pe.max) / bin_width_cut_scaled / (2 * sqrt(2 * log(2))) )
         else
-            rount(Int, peakfinder_σ)  
+            isinteger(peakfinder_σ) || throw(ArgumentError("Expected `peakfinder_σ` to be an integer, but received $peakfinder_σ."))
+            round(Int, peakfinder_σ)  
         end
         @debug "Peakfinder σ: $(peakfinder_σ_scaled)"
         try
@@ -78,7 +79,8 @@ function sipm_simple_calibration(pe_uncal::Vector{<:Real};
         peakfinder_σ_scaled = if peakfinder_σ <= 0.0
             round(Int, 2*(cuts_1pe.high - cuts_1pe.max) / bin_width_cut_scaled / (2 * sqrt(2 * log(2))) )
         else
-            rount(Int, peakfinder_σ)
+            isinteger(peakfinder_σ) || throw(ArgumentError("Expected `peakfinder_σ` to be an integer, but received $peakfinder_σ."))
+            round(Int, peakfinder_σ)
         end
         
         # use SavitzkyGolay filter to smooth the histogram


### PR DESCRIPTION
In 8c62c6a766e0b2a9ecf84a12200348fe00aaa115, the explicit `Int` declaration of `peakfinder_σ_scaled` was removed.
Therefore, we should check if `peakfinder_σ_scaled` can be converted to an integer (despite fixing the typo in `rount`)