### PR TITLE
Bug Fix `A/E` CTC

### DIFF
--- a/ext/LegendSpecFitsRecipesBaseExt.jl
+++ b/ext/LegendSpecFitsRecipesBaseExt.jl
@@ -1300,7 +1300,7 @@ end
     end
 end
 
-@recipe function f(report::NamedTuple{(:peak, :window, :fct, :bin_width, :bin_width_qdrift, :aoe_peak, :aoe_ctc, :qdrift_peak, :h_before, :h_after, :σ_before, :σ_after, :report_before, :report_after)})
+@recipe function f(report::NamedTuple{(:peak, :window, :fct, :bin_width, :bin_width_qdrift, :aoe_peak, :aoe_ctc, :aoe_ctc_norm, :qdrift_peak, :h_before, :h_after, :h_after_norm, :σ_before, :σ_after, :σ_after_norm, :report_before, :report_after, :report_after_norm)})
     
     size --> (1000,1000)
     layout := @layout [a{0.4h}; b{0.6h}]

--- a/src/aoe_ctc.jl
+++ b/src/aoe_ctc.jl
@@ -57,9 +57,9 @@ function ctc_aoe(aoe_all::Vector{<:Real}, ecal_all::Vector{<:Unitful.RealOrRealQ
         # calculate drift time corrected aoe
         aoe_ctc = aoe .+ PolCalFunc(0.0, fct...).(qdrift_e)
         # fit peak
-        h = fit(Histogram, aoe_ctc, minimum(aoe_ctc):bin_width:maximum(aoe_ctc))
+        h = fit(Histogram, aoe_ctc, hist_start:bin_width:maximum(aoe_ctc))
         ps = estimate_single_peak_stats_psd(h)
-        h = fit(Histogram, aoe_ctc, minimum(aoe_ctc):bin_width:ps.peak_pos+ps.peak_fwhm)
+        h = fit(Histogram, aoe_ctc, hist_start:bin_width:ps.peak_pos+ps.peak_fwhm)
         result_peak, report_peak = fit_single_aoe_compton(h, ps, fit_func=:aoe_two_bck, pseudo_prior=pseudo_prior, uncertainty=false) ### in ctc.jl uncertainty false is used (but I don't know why)
         # get σ and peak height
         μ = mvalue(result_peak.μ)

--- a/src/aoe_ctc.jl
+++ b/src/aoe_ctc.jl
@@ -111,7 +111,7 @@ function ctc_aoe(aoe_all::Vector{<:Real}, ecal_all::Vector{<:Unitful.RealOrRealQ
     aoe_ctc_func = "( ( $(aoe_expression) ) + " * join(["$(fct[i]) * ( $(qdrift_expression) )^$(i)" for i in eachindex(fct)], " + ") * " - $(μ_norm) ) / $(σ_norm) "
     
     # create final histograms
-    h_after = fit(Histogram, aoe_ctc, hist_start:bin_width:hist_end) ### hard-coded values: should include some tolerance to higher values
+    h_after = fit(Histogram, _aoe_ctc, hist_start:bin_width:hist_end) ### hard-coded values: should include some tolerance to higher values
     ps_after = estimate_single_peak_stats(h_after)
     result_after, report_after = fit_single_aoe_compton(h_after, ps_after, fit_func=:aoe_two_bck, pseudo_prior = pseudo_prior, uncertainty=true)
 
@@ -133,7 +133,7 @@ function ctc_aoe(aoe_all::Vector{<:Real}, ecal_all::Vector{<:Unitful.RealOrRealQ
         bin_width = bin_width,
         bin_width_qdrift = bin_width_qdrift,
         aoe_peak = aoe_cut,
-        aoe_ctc = aoe_ctc, 
+        aoe_ctc = _aoe_ctc, 
         qdrift_peak = qdrift_e_cut,
         h_before = h_before,
         h_after = h_after,

--- a/src/aoe_ctc.jl
+++ b/src/aoe_ctc.jl
@@ -47,7 +47,8 @@ function ctc_aoe(aoe_all::Vector{<:Real}, ecal_all::Vector{<:Unitful.RealOrRealQ
     # get σ before correction
     # fit peak (with the aoe_two_bck fit function which uses two EMGs)
     h_before = fit(Histogram, aoe_cut, hist_start:bin_width:hist_end) ### the current values: hist_start -20 and hist_end 3
-    ps_before = estimate_single_peak_stats(h_before)
+    ps_before = estimate_single_peak_stats_psd(h_before)
+    h_before = fit(Histogram, aoe_cut, hist_start:bin_width:ps_before.peak_pos+ps_before.peak_fwhm) ### the current values: hist_start -20 and hist_end 3
     result_before, report_before = fit_single_aoe_compton(h_before, ps_before, fit_func=:aoe_two_bck, pseudo_prior=pseudo_prior, uncertainty=true)
     @debug "Found Best σ before correction: $(round(result_before.σ, digits=2))"
 
@@ -57,7 +58,8 @@ function ctc_aoe(aoe_all::Vector{<:Real}, ecal_all::Vector{<:Unitful.RealOrRealQ
         aoe_ctc = aoe .+ PolCalFunc(0.0, fct...).(qdrift_e)
         # fit peak
         h = fit(Histogram, aoe_ctc, minimum(aoe_ctc):bin_width:maximum(aoe_ctc))
-        ps = estimate_single_peak_stats(h)
+        ps = estimate_single_peak_stats_psd(h)
+        h = fit(Histogram, aoe_ctc, minimum(aoe_ctc):bin_width:ps.peak_pos+ps.peak_fwhm)
         result_peak, report_peak = fit_single_aoe_compton(h, ps, fit_func=:aoe_two_bck, pseudo_prior=pseudo_prior, uncertainty=false) ### in ctc.jl uncertainty false is used (but I don't know why)
         # get σ and peak height
         μ = mvalue(result_peak.μ)
@@ -100,20 +102,22 @@ function ctc_aoe(aoe_all::Vector{<:Real}, ecal_all::Vector{<:Unitful.RealOrRealQ
     _aoe_ctc = aoe_cut .+ PolCalFunc(0.0, fct...).(qdrift_e_cut)
     
     # normalize once again to μ = 0 and σ = 1
-    h_norm = fit(Histogram, _aoe_ctc, -20:bin_width:3) ### hard-coded values: should include some tolerance to higher values
-    ps_norm = estimate_single_peak_stats(h_norm)
-    result_norm, report_norm = fit_single_aoe_compton(h_norm, ps_norm, fit_func=:aoe_two_bck, pseudo_prior = pseudo_prior_all, uncertainty=true)
-    μ_norm = mvalue(result_norm.μ)
-    σ_norm = mvalue(result_norm.σ)
+    h_after = fit(Histogram, _aoe_ctc, hist_start:bin_width:hist_end) ### hard-coded values: should include some tolerance to higher values
+    ps_after = estimate_single_peak_stats_psd(h_after)
+    h_after = fit(Histogram, _aoe_ctc, hist_start:bin_width:ps_after.peak_pos+ps_after.peak_fwhm)
+    result_after, report_after = fit_single_aoe_compton(h_after, ps_after, fit_func=:aoe_two_bck, pseudo_prior = pseudo_prior_all, uncertainty=true)
+    μ_norm = mvalue(result_after.μ)
+    σ_norm = mvalue(result_after.σ)
     aoe_ctc = (_aoe_ctc .- μ_norm) ./ σ_norm
 
     # get cal PropertyFunctions
     aoe_ctc_func = "( ( $(aoe_expression) ) + " * join(["$(fct[i]) * ( $(qdrift_expression) )^$(i)" for i in eachindex(fct)], " + ") * " - $(μ_norm) ) / $(σ_norm) "
     
     # create final histograms
-    h_after = fit(Histogram, _aoe_ctc, hist_start:bin_width:hist_end) ### hard-coded values: should include some tolerance to higher values
-    ps_after = estimate_single_peak_stats(h_after)
-    result_after, report_after = fit_single_aoe_compton(h_after, ps_after, fit_func=:aoe_two_bck, pseudo_prior = pseudo_prior, uncertainty=true)
+    h_after_norm = fit(Histogram, aoe_ctc, hist_start:bin_width:hist_end) ### hard-coded values: should include some tolerance to higher values
+    ps_after_norm = estimate_single_peak_stats_psd(h_after_norm)
+    h_after_norm = fit(Histogram, aoe_ctc, hist_start:bin_width:ps_after_norm.peak_pos+ps_after_norm.peak_fwhm) ### hard-coded values: should include some tolerance to higher values
+    result_after_norm, report_after_norm = fit_single_aoe_compton(h_after_norm, ps_after_norm, fit_func=:aoe_two_bck, pseudo_prior = pseudo_prior, uncertainty=true)
 
 
     ### maybe modify result and report (also depending on the recipe)
@@ -124,6 +128,7 @@ function ctc_aoe(aoe_all::Vector{<:Real}, ecal_all::Vector{<:Unitful.RealOrRealQ
         fct = fct,
         σ_before = result_before.σ,
         σ_after = result_after.σ,
+        σ_after_norm = result_after_norm.σ,
         converged = converged
     )
     report = (
@@ -134,13 +139,17 @@ function ctc_aoe(aoe_all::Vector{<:Real}, ecal_all::Vector{<:Unitful.RealOrRealQ
         bin_width_qdrift = bin_width_qdrift,
         aoe_peak = aoe_cut,
         aoe_ctc = _aoe_ctc, 
+        aoe_ctc_norm = aoe_ctc, 
         qdrift_peak = qdrift_e_cut,
         h_before = h_before,
         h_after = h_after,
+        h_after_norm = h_after_norm,
         σ_before = result.σ_before,
         σ_after = result.σ_after,
+        σ_after_norm = result.σ_after_norm,
         report_before = report_before,
-        report_after = report_after
+        report_after = report_after,
+        report_after_norm = report_after_norm
     )
     return result, report
 end

--- a/src/aoe_pseudo_prior.jl
+++ b/src/aoe_pseudo_prior.jl
@@ -4,7 +4,7 @@ function get_aoe_standard_pseudo_prior(h::Histogram, ps::NamedTuple, fit_func::S
         σ = weibull_from_mx(ps.peak_sigma, 1.5*ps.peak_sigma),
         n = weibull_from_mx(ps.peak_counts, 1.5*ps.peak_counts),
         B = LogUniform(0.1*ps.mean_background, 10*ps.mean_background),
-        δ = LogUniform(0.001, 10.0),
+        δ = weibull_from_mx(2*ps.peak_fwhm, 3*ps.peak_fwhm),
         μ2 = Normal(-2, 5),
         σ2 = weibull_from_mx(4, 6),
         B2 = weibull_from_mx(0.8*ps.peak_counts, 1.2*ps.peak_counts),


### PR DESCRIPTION
This PR updates th `aoe_ctc` functionality to improve the routine:
- The `pseudo_prior` is udpated to prevent the first EMG in the CC to model the signal contribution
- The routine cut each histogram based on the `peakstats` by having an upper limit of `µ + FWHM` since we currently don't have any modeling for the high `A/E` side
- Updates and bug fixes to `result` and `report` 

This PR also updates the `report` to plot the non-normalized distribution after the correction. This helps in my opinion the clarity of the `A/E` `CTC` plotting.

CC @verenaaur 

![aoe_ctc (1)](https://github.com/user-attachments/assets/4c4695f9-0962-481e-9f9f-ea14433ecfca)
