### PR TITLE
Rewrite `get_pe_res`: numerical FWHM calculation

### DIFF
--- a/src/sipmfit.jl
+++ b/src/sipmfit.jl
@@ -109,9 +109,9 @@ function fit_sipm_spectrum(pe_cal::Vector{<:Real}, min_pe::Real=0.5, max_pe::Rea
     # get pe resolution (FWHM)
     get_pe_res = pe -> let sel = in.(μ, (-Δpe_peak_assignment..Δpe_peak_assignment) .+ pe)
         model_parameters = [
-            Vector(view(μ_ml, sel)),
-            Vector(view(σ_ml, sel)),
-            Vector(view(w_ml, sel))
+            view(μ_ml, sel),
+            view(σ_ml, sel),
+            view(w_ml, sel)
         ]
         
         # Find maximum of PDF in the expected range, step size depends on the maximum variance of the single gaussians
@@ -196,8 +196,8 @@ function _gmm_binned_loglike_func(
     return f_loglike
 end
 
-function _gmm_pdf(x::Real, μ::Vector{<:Real}, σ::Vector{<:Real}, w::Vector{<:Real})
+function _gmm_pdf(x::Real, μ::AbstractVector{<:Real}, σ::AbstractVector{<:Real}, w::AbstractVector{<:Real})
     return sum(@. w * exp(-0.5 * ((x - μ) / σ)^2) / (σ * sqrt(2π)))
 end
 
-_gmm_pdf(x::Real, V::Vector{<:Vector{<:Real}}) = _gmm_pdf(x, V...)
+_gmm_pdf(x::Real, V::Vector{<:AbstractVector{<:Real}}) = _gmm_pdf(x, V...)

--- a/src/sipmfit.jl
+++ b/src/sipmfit.jl
@@ -26,7 +26,6 @@ Fit a Gaussian Mixture Model to the given pe calibration data and return the fit
 function fit_sipm_spectrum(pe_cal::Vector{<:Real}, min_pe::Real=0.5, max_pe::Real=3.5;
     n_mixtures::Int=ceil(Int, (max_pe - min_pe) * 4), nIter::Int=25, nInit::Int=50, 
     method::Symbol=:kmeans, kind=:diag, Δpe_peak_assignment::Real=0.3, f_uncal::Function=identity, uncertainty::Bool=true)
-    
     # first filter peak positions out of amplitude vector
     amps_fit = filter(in(min_pe..max_pe), pe_cal)
     
@@ -106,9 +105,33 @@ function fit_sipm_spectrum(pe_cal::Vector{<:Real}, min_pe::Real=0.5, max_pe::Rea
     get_pe_pos = pe -> let sel = in.(μ, (-Δpe_peak_assignment..Δpe_peak_assignment) .+ pe)
         dot(view(μ, sel), view(w, sel)) / sum(view(w, sel))
     end
+
+    # get pe resolution (FWHM)
     get_pe_res = pe -> let sel = in.(μ, (-Δpe_peak_assignment..Δpe_peak_assignment) .+ pe)
-        sqrt(dot(view(σ, sel).^2, view(w, sel).^2))
-    end 
+        model_parameters = [
+            view(μ_ml, sel),
+            view(σ_ml, sel),
+            view(w_ml, sel)
+        ]    
+        
+        # Find maximum of PDF in the expected range, step size depends on the maximum variance of the single gaussians
+        range_steps = maximum([μ[i].err for i in size(μ)]) / 100
+        x_max = 0.0
+        f_max = 0.0
+        for x_i in 0.8:range_steps:1.2
+            if _gmm_pdf(x_i, model_parameters) > f_max
+                x_max = x_i
+                f_max = _gmm_pdf(x_i, model_parameters)
+            end
+        end
+        f_half_max = f_max / 2
+
+        # Find all the points where the half max is reached
+        roots = find_zeros(x -> f_half_max - _gmm_pdf(x, model_parameters), 0, 5)
+        return maximum(roots) - minimum(roots)
+    end
+
+
     n_pos_mixtures = [count(in.(μ, (-Δpe_peak_assignment..Δpe_peak_assignment) .+ pe)) for pe in pes]
 
     pe_pos = get_pe_pos.(pes)
@@ -171,3 +194,9 @@ function _gmm_binned_loglike_func(
     )
     return f_loglike
 end
+
+function _gmm_pdf(x::Real, μ::Vector{<:Real}, σ::Vector{<:Real}, w::Vector{<:Real})
+    return sum(w .* exp.(-0.5 .* ((x .- μ) ./ σ).^2) ./ (σ .* sqrt(2π)))
+end
+
+_gmm_pdf(x::Real, V::Vector{<:Vector{<:Real}}) = _gmm_pdf(x, V[1], V[2], V[3])


### PR DESCRIPTION
Fix #130.

The previous implementation of the `get_pe_res` function was incorrect. Since there is no closed formula for the FWHM of a gaussian mixture, it is now calculated numerically.

For each given subset of the gaussian mixture model, the maximum of the resulting PDF is calculated by dividing the interval [0.8, 1.2] into small steps. The step size depends on the largest variance of the individual gaussians, which ensures a high enough accuracy for the estimated maximum.

After that, all values where the half maximum is reached are calculated with the `find_zeros` function from `Roots.jl`. The FWHM then corresponds to the difference between the largest and the smallest position.