### PR TITLE
`A/E` CTC update

### DIFF
--- a/src/aoe_pseudo_prior.jl
+++ b/src/aoe_pseudo_prior.jl
@@ -4,7 +4,7 @@ function get_aoe_standard_pseudo_prior(h::Histogram, ps::NamedTuple, fit_func::S
         σ = weibull_from_mx(ps.peak_sigma, 1.5*ps.peak_sigma),
         n = weibull_from_mx(ps.peak_counts, 1.5*ps.peak_counts),
         B = LogUniform(0.1*ps.mean_background, 10*ps.mean_background),
-        δ = weibull_from_mx(2*ps.peak_fwhm, 3*ps.peak_fwhm),
+        δ = LogUniform(0.05, 10.0),
         μ2 = Normal(-2, 5),
         σ2 = weibull_from_mx(4, 6),
         B2 = weibull_from_mx(0.8*ps.peak_counts, 1.2*ps.peak_counts),

--- a/src/aoe_pseudo_prior.jl
+++ b/src/aoe_pseudo_prior.jl
@@ -4,7 +4,7 @@ function get_aoe_standard_pseudo_prior(h::Histogram, ps::NamedTuple, fit_func::S
         σ = weibull_from_mx(ps.peak_sigma, 1.5*ps.peak_sigma),
         n = weibull_from_mx(ps.peak_counts, 1.5*ps.peak_counts),
         B = LogUniform(0.1*ps.mean_background, 10*ps.mean_background),
-        δ = LogUniform(0.1, 50.0),
+        δ = weibull_from_mx(2*ps.peak_fwhm, 3*ps.peak_fwhm),
         μ2 = Normal(-2, 5),
         σ2 = weibull_from_mx(4, 6),
         B2f = Uniform(0.001, 0.999),

--- a/src/aoe_pseudo_prior.jl
+++ b/src/aoe_pseudo_prior.jl
@@ -4,22 +4,24 @@ function get_aoe_standard_pseudo_prior(h::Histogram, ps::NamedTuple, fit_func::S
         σ = weibull_from_mx(ps.peak_sigma, 1.5*ps.peak_sigma),
         n = weibull_from_mx(ps.peak_counts, 1.5*ps.peak_counts),
         B = LogUniform(0.1*ps.mean_background, 10*ps.mean_background),
-        δ = LogUniform(0.05, 10.0),
+        δ = LogUniform(0.1, 50.0),
         μ2 = Normal(-2, 5),
         σ2 = weibull_from_mx(4, 6),
-        B2 = weibull_from_mx(0.8*ps.peak_counts, 1.2*ps.peak_counts),
-        δ2 = weibull_from_mx(5.0, 10.0),
+        B2f = Uniform(0.001, 0.999),
+        δ2 = LogUniform(0.1, 100.0),
     )
 
     # extract single prior arguments
-    (; μ, σ, n, B, δ, µ2, σ2, B2, δ2) = pprior_base
+    (; μ, σ, n, B, δ, µ2, σ2, B2f, δ2) = pprior_base
 
     # select prior based on fit function
     if fit_func == :aoe_one_bck
         NamedTupleDist(; μ, σ, n, B, δ)
     elseif fit_func == :aoe_two_bck
-        B = weibull_from_mx(0.25*ps.peak_counts, 0.5*ps.peak_counts)
-        NamedTupleDist(; μ, σ, n, B, δ, μ2, σ2, B2, δ2)
+        δ = weibull_from_mx(10*ps.peak_sigma, 20*ps.peak_sigma)
+        σ = Uniform(0.99*ps.peak_sigma, 1.2*ps.peak_sigma)
+        n = LogUniform(0.5*ps.peak_counts, 5*ps.peak_counts)
+        NamedTupleDist(; μ, σ, n, B, δ, μ2, σ2, B2f, δ2)
     else
         throw(ArgumentError("fit_func $fit_func not supported for aoe peakshapes"))
     end

--- a/src/aoefit_functions.jl
+++ b/src/aoefit_functions.jl
@@ -9,7 +9,7 @@ MaybeWithEnergyUnits = Union{Real, Unitful.Energy{<:Real}}
 function get_aoe_fit_functions(; background_center::Union{Real,Nothing} = nothing)
     merge( 
         (aoe_one_bck = (x, v) -> aoe_compton_peakshape(x, v.μ, v.σ, v.n, v.B, v.δ),
-        aoe_two_bck = (x, v) -> two_emg_aoe_compton_peakshape(x, v.μ, v.σ, v.n, v.B, v.δ, v.μ2, v.σ2, v.B2, v.δ2),
+        aoe_two_bck = (x, v) -> two_emg_aoe_compton_peakshape(x, v.μ, v.σ, v.n, v.B, v.δ, v.μ2, v.σ2, v.B2f, v.δ2),
         ),
     if isnothing(background_center)
         NamedTuple()
@@ -33,8 +33,8 @@ function aoe_compton_peakshape_components(fit_func::Symbol; background_center::U
         linestyles = (f_sig = :solid, f_bck = :dash)
     elseif fit_func == :aoe_two_bck
         funcs = (f_sig = (x, v) -> aoe_compton_signal_peakshape(x, v.μ, v.σ, v.n),
-            f_bck_one = (x, v) -> aoe_compton_background_peakshape(x, v.μ, v.σ, v.B, v.δ),
-            f_bck_two = (x, v) -> aoe_compton_background_peakshape(x, v.μ2, v.σ2, v.B2, v.δ2)) #maybe use one function only
+            f_bck_one = (x, v) -> aoe_compton_background_peakshape(x, v.μ, v.σ, v.B * (1 - v.B2f), v.δ),
+            f_bck_two = (x, v) -> aoe_compton_background_peakshape(x, v.μ2, v.σ2, v.B * v.B2f, v.δ2)) #maybe use one function only
         labels = (f_sig = "Signal", f_bck_one = "First EMG", f_bck_two = "Second EMG")
         colors = (f_sig = :orangered1, f_bck_one = :dodgerblue2, f_bck_two = :green)
         linestyles = (f_sig = :solid, f_bck_one = :dash, f_bck_two = :dashdot)

--- a/src/peakshapes.jl
+++ b/src/peakshapes.jl
@@ -258,17 +258,17 @@ export double_gaussian
 function two_emg_aoe_compton_peakshape( # total fit function with two EMGs
     x::Real, 
     μ::Real, σ::Real, n::Real, background::Real, δ::Real, 
-    μ2::Real, σ2::Real, background2::Real, δ2::Real
+    μ2::Real, σ2::Real, background2_fraction::Real, δ2::Real
 )
-    return iszero(σ) || iszero(σ2) ? zero(x) : n * gauss_pdf(x, μ, σ) + background * ex_gauss_pdf(-x, -μ, σ, δ) + background2 * ex_gauss_pdf(-x, -μ2, σ2, δ2)
+    return iszero(σ) || iszero(σ2) ? zero(x) : n * gauss_pdf(x, μ, σ) + background * ( (1 - background2_fraction) * ex_gauss_pdf(-x, -μ, σ, δ) + background2_fraction * ex_gauss_pdf(-x, -μ2, σ2, δ2))
 end
 export two_emg_aoe_compton_peakshape
 
 function two_emg_aoe_compton_background_peakshape( # background function with two EMGs
     x::Real, 
     μ::Real, σ::Real, background::Real, δ::Real,
-    μ2::Real, σ2::Real, background2::Real, δ2::Real
+    μ2::Real, σ2::Real, background2_fraction::Real, δ2::Real
 )
-    return background * ex_gauss_pdf(-x, -μ, σ, δ) + background2 * ex_gauss_pdf(-x, -μ2, σ2, δ2)
+    return background * ( (1 - background2_fraction) * ex_gauss_pdf(-x, -μ, σ, δ) + background2_fraction * ex_gauss_pdf(-x, -μ2, σ2, δ2))
 end
 export two_aoe_compton_background_peakshape


### PR DESCRIPTION
This PR updates the `A/E` CTC routines for more precise handling of the CTC correction and normalization of the classifier. It includes:
- New `fit_binned_half_trunc_gauss` fit routine for increased performance
- Modified `two_emg_aoe_compton_peakshape` to have only one background rate and a `fraction` parameter to split between the two EMGs
- Modified `fit_aoe_compton` to calculate `FWHM` of `SSE` in each fit
- Modified `aoe_ctc` to use `fit_half_trunc_gauss` for all fit related to the CTC optimization and normalization

CC @verenaaur  