### PR TITLE
Patch `CTC` energy

### DIFF
--- a/src/ctc.jl
+++ b/src/ctc.jl
@@ -40,9 +40,11 @@ function ctc_energy(e::Vector{<:Unitful.Energy{<:Real}}, qdrift::Vector{<:Real},
         # fit peak
         h = fit(Histogram, e_ctc, minimum(e_ctc):bin_width:maximum(e_ctc))
         ps = estimate_single_peak_stats(h)
+        @info ps.peak_fwhm
         result_peak, report_peak = fit_single_peak_th228(h, ps; uncertainty=false)
         # get fwhm and peak height
         fwhm = mvalue(result_peak.fwhm)
+        @info "FWHM: $fwhm"
         p_height = maximum(report_peak.f_fit.(mvalue(result_peak.μ-0.2*result_peak.σ):0.01:mvalue(result_peak.μ+0.2*result_peak.σ)))
         # use ratio of fwhm and peak height as optimization functional
         return log(fwhm/p_height)
@@ -59,10 +61,10 @@ function ctc_energy(e::Vector{<:Unitful.Energy{<:Real}}, qdrift::Vector{<:Real},
     fct_lb = [(ustrip(e_unit, 1e-4u"keV") / qdrift_median)^(i) for i in 1:pol_order] .* e_unit
     @debug "Lower bound: $fct_lb"
     # lower bound
-    fct_ub = [(ustrip(e_unit, 5u"keV") / qdrift_median)^(i) for i in 1:pol_order] .* e_unit
+    fct_ub = [(ustrip(e_unit, 7u"keV") / qdrift_median)^(i) for i in 1:pol_order] .* e_unit
     @debug "Upper bound: $fct_ub"
     # start value
-    fct_start = [(ustrip(e_unit, 0.1u"keV") / qdrift_median)^(i) for i in 1:pol_order] .* e_unit
+    fct_start = [(ustrip(e_unit, i*1.0u"keV") / qdrift_median)^(i) for i in 1:pol_order] .* e_unit
     @debug "Start value: $fct_start"
 
     # optimization

--- a/src/ctc.jl
+++ b/src/ctc.jl
@@ -40,11 +40,9 @@ function ctc_energy(e::Vector{<:Unitful.Energy{<:Real}}, qdrift::Vector{<:Real},
         # fit peak
         h = fit(Histogram, e_ctc, minimum(e_ctc):bin_width:maximum(e_ctc))
         ps = estimate_single_peak_stats(h)
-        @info ps.peak_fwhm
         result_peak, report_peak = fit_single_peak_th228(h, ps; uncertainty=false)
         # get fwhm and peak height
         fwhm = mvalue(result_peak.fwhm)
-        @info "FWHM: $fwhm"
         p_height = maximum(report_peak.f_fit.(mvalue(result_peak.μ-0.2*result_peak.σ):0.01:mvalue(result_peak.μ+0.2*result_peak.σ)))
         # use ratio of fwhm and peak height as optimization functional
         return log(fwhm/p_height)


### PR DESCRIPTION
This PR increases the starting value to allow the `CTC` to converge easier. The earlier implementation could lead to non-converging trapping corrections such as: 
<img width="822" alt="image" src="https://github.com/user-attachments/assets/4bf6744c-810a-4864-9182-8277ed619865" />


After the update, the same channel looks like:
<img width="812" alt="image" src="https://github.com/user-attachments/assets/94d25619-728a-49e7-8b48-bff6f1ac4242" />
