### PR TITLE
add special handling for case when dof = 0

### DIFF
--- a/src/chi2fit.jl
+++ b/src/chi2fit.jl
@@ -94,7 +94,13 @@ function chi2fit(f_fit::Function, x::AbstractVector{<:Union{Real,Measurement{<:R
             # gof 
             chi2min = res.objective
             dof = length(x) - length(v_chi2)
-            pvalue = ccdf(Chisq(dof), chi2min)
+            pvalue = if iszero(dof)
+                @warn "The number of fit parameters is equivalent to number of data points --> dof = 0 ; p-value not meaningful, set to NaN"
+                NaN
+            else 
+                ccdf(Chisq(dof), chi2min)
+            end 
+
             function get_y_pred_err(f_fit, x_val, x_err, pars)  # get final uncertainties for normalized residuals
                 dual_x = ForwardDiff.Dual{UncertTag}(x_val, x_err)
                 dual_y = f_fit(dual_x, pars...)

--- a/test/test_fit_chisq.jl
+++ b/test/test_fit_chisq.jl
@@ -30,5 +30,6 @@ using Test
     x = [1,2]
     y = f_lin.(x,par_true...) .+ 0.5.*randn(2)
     @info "chisq fit with 2 fit parameter on 2 data points (test of gof)"
-    result, report       = chi2fit(1, x, y; pull_t = [(mean = par_true[1], std= 0.1),(mean = par_true[2],std= 0.1)], uncertainty=true) 
+    @test_logs (:warn,) result, report       = chi2fit(1, x, y; pull_t = [(mean = par_true[1], std= 0.1),(mean = par_true[2],std= 0.1)], uncertainty=true) 
+    @test isnan(report.gof.pvalue) # check that the p-value is NaN
 end

--- a/test/test_fit_chisq.jl
+++ b/test/test_fit_chisq.jl
@@ -26,4 +26,9 @@ using Test
     result, report       = chi2fit(1, x, y; pull_t = [(mean = par_true[1], std= 0.1),(mean = par_true[2],std= 0.1)], uncertainty=true) 
     @test isapprox(result.par[1], par_true[1], atol = 0.2*par_true[1])
     @test isapprox(result.par[2], par_true[2], atol = 0.2*par_true[2])
+
+    x = [1,2]
+    y = f_lin.(x,par_true...) .+ 0.5.*randn(2)
+    @info "chisq fit with 2 fit parameter on 2 data points (test of gof)"
+    result, report       = chi2fit(1, x, y; pull_t = [(mean = par_true[1], std= 0.1),(mean = par_true[2],std= 0.1)], uncertainty=true) 
 end


### PR DESCRIPTION
- Fixed p-value error in case when  `number fit parameter =  number of data points`
- example: linear energy calibration function for 2 Co-60 peaks
- previously error prevented  uncertainties to be calculated
- Now: `p-value = NaN`, but fit parameter uncertainties still provided 

