### PR TITLE
Add minimal fit function for gamma peaks

### DIFF
--- a/src/pseudo_prior.jl
+++ b/src/pseudo_prior.jl
@@ -33,6 +33,8 @@ function get_standard_pseudo_prior(h::Histogram, ps::NamedTuple{(:peak_pos, :pea
         NamedTupleDist(; μ, σ, n, skew_fraction, skew_width, background, step_amplitude, background_slope)
     elseif fit_func == :gamma_bckExp
         NamedTupleDist(; μ, σ, n, skew_fraction, skew_width, background, step_amplitude, background_exp)
+    elseif fit_func == :gamma_minimal
+        NamedTupleDist(; μ, σ, n, background)
     else
         throw(ArgumentError("Unknown fit function: $fit_func"))
     end
@@ -268,6 +270,20 @@ function get_subpeaks_v_ml(v::NamedTuple, fit_func::Symbol)
                 step_amplitude = v.step_amplitude * (1 - v.sasf),
                 background_exp = v.background_exp_cut,
             )
+        v_survived, v_cut
+    elseif fit_func == :gamma_minimal 
+        v_survived = (
+            μ = v.μ, 
+            σ = v.σ_survived, 
+            n = v.n * v.sf, 
+            background = v.background * v.bsf,
+        )
+        v_cut = (
+            μ = v.μ, 
+            σ = v.σ_cut, 
+            n = v.n * (1 - v.sf), 
+            background = v.background * (1 - v.bsf),
+        )
         v_survived, v_cut
     else
         throw(ArgumentError("Unknown fit function: $fit_func"))

--- a/src/specfit.jl
+++ b/src/specfit.jl
@@ -194,7 +194,11 @@ export fit_single_peak_th228
 calculate centroid of gamma peak from fit parameters
 """
 function peak_centroid(v::NamedTuple)
-    centroid = v.μ - v.skew_fraction * (v.µ * v.skew_width)
+    centroid = if haskey(v, :skew_fraction)
+       v.μ - v.skew_fraction * (v.µ * v.skew_width)
+    else
+        v.μ
+    end 
     if haskey(v, :skew_fraction_highE)
         centroid += v.skew_fraction_highE * (v.µ * v.skew_width_highE)
     end

--- a/src/specfit_functions.jl
+++ b/src/specfit_functions.jl
@@ -8,6 +8,7 @@ This function defines the gamma peakshape fit functions used in the calibration 
 * gamma_bckExp: default gamma peakshape + exponential background 
 * gamma_bckFlat: default gamma peakshape - step background (only flat component!)
 * gamma_tails_bckFlat: default gamma peakshape + high-energy tail - step background (only flat component!)
+* gamma_minimal: only Gaussian signal and flat background
 """
 function get_th228_fit_functions(; background_center::Union{Real,Nothing} = nothing)
     merge( 
@@ -16,6 +17,7 @@ function get_th228_fit_functions(; background_center::Union{Real,Nothing} = noth
         gamma_sigWithTail = (x, v) -> signal_peakshape(x, v.μ, v.σ, v.n, v.skew_fraction) + lowEtail_peakshape(x, v.μ, v.σ, v.n, v.skew_fraction, v.skew_width),
         gamma_bckFlat = (x, v) -> gamma_peakshape(x, v.μ, v.σ, v.n, 0.0, v.skew_fraction, v.skew_width, v.background),
         gamma_tails_bckFlat = (x, v) -> gamma_peakshape(x, v.μ, v.σ, v.n, 0.0, v.skew_fraction, v.skew_width , v.background; skew_fraction_highE = v.skew_fraction_highE, skew_width_highE = v.skew_width_highE),
+        gamma_minimal = (x, v) -> gamma_peakshape(x, v.μ, v.σ, v.n, 0.0, 0.0, 0.0, v.background),
         ),
     if isnothing(background_center)
         (gamma_bckSlope = (x, v) -> gamma_peakshape(x, v.μ, v.σ, v.n, v.step_amplitude, v.skew_fraction, v.skew_width, v.background; background_slope =  v.background_slope, background_center = v.μ),
@@ -60,6 +62,10 @@ function peakshape_components(fit_func::Symbol; background_center::Union{Real,No
         funcs = (f_sig = (x, v) -> signal_peakshape(x, v.μ, v.σ, v.n, (v.skew_fraction + v.skew_fraction_highE)),
             f_lowEtail = (x, v) -> lowEtail_peakshape(x, v.μ, v.σ, v.n, v.skew_fraction, v.skew_width),
             f_highEtail = (x, v) -> highEtail_peakshape(x, v.μ, v.σ, v.n, v.skew_fraction_highE, v.skew_width_highE), 
+            f_bck = (x, v) -> background_peakshape(x, v.μ, v.σ, 0.0, v.background))
+    elseif fit_func == :gamma_minimal
+            funcs = (f_sig = (x, v) -> signal_peakshape(x, v.μ, v.σ, v.n, 0.0),
+            f_lowEtail = (x, v) -> lowEtail_peakshape(x, v.μ, v.σ, v.n, 0.0, 0.0),
             f_bck = (x, v) -> background_peakshape(x, v.μ, v.σ, 0.0, v.background))
     end 
     labels = (f_sig = "Signal", f_lowEtail = "Low-energy tail", f_bck = "Background", f_highEtail = "High-energy tail")

--- a/test/test_fit_chisq.jl
+++ b/test/test_fit_chisq.jl
@@ -6,18 +6,24 @@ using Test
 @testset "fit_chisq" begin
     par_true = [5, 2]
     f_lin(x,p1,p2)  = p1 +  p2 * x 
-    x = [1,2,3,4,5,6,7,8,9,10] #.± ones(10)
+    x = [1,2,3,4,5,6,7,8,9,10]
     y = f_lin.(x,par_true...) .+ 0.5.*randn(10)
     @info "chisq fit without uncertainties on x and y "
     result, report       = chi2fit(1, x, y; uncertainty=true) 
-  
+    @test isapprox(result.par[1], par_true[1], atol = 0.2*par_true[1])
+    @test isapprox(result.par[2], par_true[2], atol = 0.2*par_true[2])
+
     x = [1,2,3,4,5,6,7,8,9,10] .± ones(10)
     y = f_lin.(x,par_true...) .+ 0.5.*randn(10)
     @info "chisq fit with uncertainties on x and y"
     result, report       = chi2fit(1, x, y; uncertainty=true) 
-    
+    @test isapprox(result.par[1], par_true[1], atol = 0.2*par_true[1])
+    @test isapprox(result.par[2], par_true[2], atol = 0.2*par_true[2])
+
     x = [1,2,3,4,5,6,7,8,9,10] .± ones(10)
     y = f_lin.(x,par_true...) .+ 0.5.*randn(10)
     @info "chisq fit with uncertainties on x and y"
     result, report       = chi2fit(1, x, y; pull_t = [(mean = par_true[1], std= 0.1),(mean = par_true[2],std= 0.1)], uncertainty=true) 
+    @test isapprox(result.par[1], par_true[1], atol = 0.2*par_true[1])
+    @test isapprox(result.par[2], par_true[2], atol = 0.2*par_true[2])
 end

--- a/test/test_specfit.jl
+++ b/test/test_specfit.jl
@@ -18,7 +18,8 @@ include("test_utils.jl")
     result_simple, report_simple = simple_calibration(ustrip.(energy_test), th228_lines, window_sizes, n_bins=10000,; calib_type=:th228, quantile_perc=0.995)
 
     # fit 
-    result, report = fit_peaks(result_simple.peakhists, result_simple.peakstats, ustrip.(th228_lines),; uncertainty=true,calib_type = :th228);
+    result, report = fit_peaks(result_simple.peakhists, result_simple.peakstats, ustrip.(th228_lines),; uncertainty=true,calib_type = :th228, fit_func = [:gamma_def, :gamma_tails, :gamma_bckExp, :gamma_tails_bckFlat, :gamma_bckSlope, :gamma_minimal, :gamma_bckFlat]);
+    @test all([isapprox(mvalue(result[peak].µ), ustrip(th228_lines[i]), atol = 0.2*ustrip(th228_lines[i])) for (i, peak) in enumerate(keys(result))])
 end
 
 @testset "fit_subpeaks_th228" begin


### PR DESCRIPTION
- add new fit function `gamma_minimal` (only gauss + flat background) incl. pseudo-priors
- adjust fwhm calculation for case w/o low-energy tail
- improve tests