### PR TITLE
Simple cal

### DIFF
--- a/src/LegendSpecFits.jl
+++ b/src/LegendSpecFits.jl
@@ -48,6 +48,7 @@ using Unitful
 using ValueShapes
 
 MaybeWithEnergyUnits = Union{Real, Unitful.Energy{<:Real}}
+const e_unit=u"keV"
 
 include("utils.jl")
 include("memory_utils.jl")

--- a/src/aoe_cut.jl
+++ b/src/aoe_cut.jl
@@ -37,8 +37,6 @@ function get_low_aoe_cut(aoe::Vector{<:Unitful.RealOrRealQuantity}, e::Vector{<:
             cut_search_interval::Tuple{<:Unitful.RealOrRealQuantity, <:Unitful.RealOrRealQuantity}=(-25.0*unit(first(aoe)), 1.0*unit(first(aoe))), 
             bin_width_window::T=3.0u"keV", max_e_plot::T=3000.0u"keV",  plot_window::Vector{<:T}=[12.0, 50.0]u"keV",
             fixed_position::Bool=true, fit_func::Symbol=:gamma_def, uncertainty::Bool=true) where T<:Unitful.Energy{<:Real}
-    # scale unit
-    e_unit = u"keV"
     # cut window around peak
     e_mask = (dep-first(window) .< e .< dep+last(window))
     aoe_dep = aoe[e_mask]

--- a/src/aoefit.jl
+++ b/src/aoefit.jl
@@ -21,7 +21,6 @@ the binning is only done in the area around the peak. The peak parameters are es
 """
 function generate_aoe_compton_bands(aoe::Vector{<:Real}, e::Vector{<:T}, compton_bands::Vector{<:T}, compton_window::T) where T<:Unitful.Energy{<:Real}
     @assert length(aoe) == length(e) "A/E and Energy arrays must have the same length"
-    e_unit = u"keV"
     # get aoe values in compton bands
     aoe_compton_bands = [aoe[c .< e .< c + compton_window .&& aoe .> 0.0] for c in compton_bands]
 

--- a/src/auto_calibration.jl
+++ b/src/auto_calibration.jl
@@ -7,7 +7,6 @@
 Compute an energy calibration from raw reconstructed energy deposition values based on a given number of known photon lines which are contained in the spectrum
 """
 function autocal_energy(e::AbstractArray{<:Real}, photon_lines::Vector{<:Unitful.Energy{<:Real}}; mode::Symbol=:fit, min_e::Real=100, max_e::Real=maximum(e), max_e_binning_quantile::Real=0.5, σ::Real = 2.0, threshold::Real = 50.0, min_n_peaks::Int = length(photon_lines), max_n_peaks::Int = 4 * length(photon_lines), α::Real = 0.01, rtol::Real = 5e-3)
-    e_unit = u"keV"
     # binning based on fd with max cut off at certain quantile
     max_e_binning = quantile(e, max_e_binning_quantile)
     bin_width = get_friedman_diaconis_bin_width(filter(x -> min_e < x < max_e_binning, e))

--- a/src/ctc.jl
+++ b/src/ctc.jl
@@ -20,7 +20,6 @@ function ctc_energy(e::Vector{<:Unitful.Energy{<:Real}}, qdrift::Vector{<:Real},
     cut = peak - first(window) .< e .< peak + last(window)
     @debug "Cut window: $(peak - first(window)) < e < $(peak + last(window))"
     e_cut, qdrift_cut = e[cut], qdrift[cut]
-    e_unit = u"keV"
     # calculate optimal bin width
     bin_width_window = 5.0u"keV"
     bin_width        = get_friedman_diaconis_bin_width(e[peak - bin_width_window .< e .< peak + bin_width_window])

--- a/src/filter_optimization.jl
+++ b/src/filter_optimization.jl
@@ -26,6 +26,7 @@ function fit_enc_sigmas(enc_grid::Matrix{T}, enc_grid_rt::StepRangeLen{<:Quantit
     Threads.@threads for r in eachindex(enc_grid_rt)
         # get rt
         rt = enc_grid_rt[r]
+        
         # get enc for this rt
         enc_rt = flatview(enc_grid)[r, :]
         # sanity check

--- a/src/filter_optimization.jl
+++ b/src/filter_optimization.jl
@@ -26,7 +26,6 @@ function fit_enc_sigmas(enc_grid::Matrix{T}, enc_grid_rt::StepRangeLen{<:Quantit
     Threads.@threads for r in eachindex(enc_grid_rt)
         # get rt
         rt = enc_grid_rt[r]
-        
         # get enc for this rt
         enc_rt = flatview(enc_grid)[r, :]
         # sanity check

--- a/src/fit_fwhm.jl
+++ b/src/fit_fwhm.jl
@@ -15,7 +15,6 @@ function fit_fwhm(pol_order::Int, peaks::Vector{<:Unitful.Energy{<:Real}}, fwhm:
     @assert pol_order >= 1 "The polynomial order must be greater than 0"
     
     # fit FWHM fit function
-    e_unit = u"keV"
     _linear_intercept(x1::Float64, x2::Float64, y1::Float64, y2::Float64) = y1 - ((y2 - y1) / (x2 - x1)) * x1
     intercept_first_two_points = _linear_intercept(mvalue.(ustrip.(e_unit,sort(peaks)[1:2]))..., mvalue.(ustrip.(e_unit, fwhm[sortperm(peaks)[1:2]]))...)
     intercept_guess = if intercept_first_two_points > 0.1

--- a/src/simple_calibration.jl
+++ b/src/simple_calibration.jl
@@ -39,7 +39,7 @@ end
 simple_calibration(e_uncal::Vector{<:Real}, gamma_lines::Vector{<:Unitful.Energy{<:Real}}, left_window_sizes::Vector{<:Unitful.Energy{<:Real}}, right_window_sizes::Vector{<:Unitful.Energy{<:Real}}; kwargs...) = simple_calibration(e_uncal, th228_lines, [(l,r) for (l,r) in zip(left_window_sizes, right_window_sizes)],; kwargs...)
 
 
-function simple_calibration_gamma(e_uncal::Vector{<:Real}, gamma_lines::Vector{<:Unitful.Energy{<:Real}}, window_sizes::Vector{<:Tuple{Unitful.Energy{<:Real}, Unitful.Energy{<:Real}}},; peaksearch_type::Symbol = :most_prominent, quantile_perc::Float64=NaN, binning_peak_window::Unitful.Energy{<:Real}=10.0u"keV", peakfinder_gamma::Int = 1, kwargs...)
+function simple_calibration_gamma(e_uncal::Vector{<:Real}, gamma_lines::Vector{<:Unitful.Energy{<:Real}}, window_sizes::Vector{<:Tuple{Unitful.Energy{<:Real}, Unitful.Energy{<:Real}}},; peaksearch_type::Symbol = :most_prominent, binning_peak_window::Unitful.Energy{<:Real}=10.0u"keV", peakfinder_gamma::Int = 1, kwargs...)
     if peaksearch_type == :most_prominent
         # use most prominent peak in spectrum and use that one. This relies on the peakfinder to find all peaks in gamma_lines!
        result_peak = peak_search_gamma(e_uncal, gamma_lines; kwargs...)

--- a/src/simple_calibration.jl
+++ b/src/simple_calibration.jl
@@ -145,10 +145,14 @@ function peak_search_gamma(e_uncal::Vector{<:Real}, gamma_lines::Vector{<:Unitfu
         peakpos_idxs = StatsBase.binindex.(Ref(h_decon), peakpos)
         cts_peakpos = h_decon.weights[peakpos_idxs]
         @debug "Peaks found at $peakpos with intensity $cts_peakpos - literature values: $(gamma_lines)"
+        if length(gamma_lines) != length(peakpos)
+            error("Number of gamma lines expected: $(length(gamma_lines)) vs. number of peaks foundL $(length(peak_guess)) -->  do not match \n try to adjust the peakfinder parameters: peakfinder_σ, peakfinder_threshold, or binning")
+        end
         peakpos[argmax(cts_peakpos)], argmax(cts_peakpos)
     else
         quantile(e_uncal, quantile_perc), length(gamma_lines)
     end
+
     if length(gamma_lines) == 1 && peak_idx > 1
         peak_idx = 1 # assume that most prominent peak is the one we are looking for
     end

--- a/src/simple_calibration.jl
+++ b/src/simple_calibration.jl
@@ -1,3 +1,4 @@
+const e_unit=u"keV" # unit for calibrated energies. All energy values will be convert to this unit
 """
     simple_calibration(e_uncal::Array, th228_lines::Array, window_size::Float64=25.0, n_bins::Int=15000, calib_type::String="th228")
 
@@ -18,54 +19,49 @@ Returns
 function simple_calibration end
 export simple_calibration
 
-function simple_calibration(e_uncal::Vector{<:Real}, th228_lines::Vector{<:Unitful.Energy{<:Real}}, window_sizes::Vector{<:Tuple{Unitful.Energy{<:Real}, Unitful.Energy{<:Real}}},; kwargs...)
+function simple_calibration(e_uncal::Vector{<:Real}, gamma_lines::Vector{<:Unitful.Energy{<:Real}}, window_sizes::Vector{<:Tuple{Unitful.Energy{<:Real}, Unitful.Energy{<:Real}}},; kwargs...)
     # remove calib type from kwargs
     @assert haskey(kwargs, :calib_type) "Calibration type not specified"
     calib_type = kwargs[:calib_type]
     # remove :calib_type from kwargs
     kwargs = pairs(NamedTuple(filter(k -> !(:calib_type in k), kwargs)))
     if calib_type == :th228
-        @debug "Use simple calibration for Th228 lines"
-        return simple_calibration_th228(e_uncal, th228_lines, window_sizes,; kwargs...)
+        @debug "Use simple calibration for Th228 lines - fix peak-search parameters"
+        kwargs = merge(NamedTuple(kwargs), (peaksearch_type = :th228, peakfinder_σ = 5.0, peakfinder_threshold = 10.0, peak_quantile = 0.9..1.0, bin_quantile = 0.05..0.5)) # give good default values for Th228
+        return simple_calibration_gamma(e_uncal, gamma_lines, window_sizes,; kwargs...)
+    elseif calib_type == :gamma
+         @debug "Use simple calibration for generic gamma lines"
+         return simple_calibration_gamma(e_uncal, gamma_lines, window_sizes,; kwargs...)
     else
         error("Calibration type not supported")
     end
 end
-simple_calibration(e_uncal::Vector{<:Real}, th228_lines::Vector{<:Unitful.Energy{<:Real}}, left_window_sizes::Vector{<:Unitful.Energy{<:Real}}, right_window_sizes::Vector{<:Unitful.Energy{<:Real}}; kwargs...) = simple_calibration(e_uncal, th228_lines, [(l,r) for (l,r) in zip(left_window_sizes, right_window_sizes)],; kwargs...)
+simple_calibration(e_uncal::Vector{<:Real}, gamma_lines::Vector{<:Unitful.Energy{<:Real}}, left_window_sizes::Vector{<:Unitful.Energy{<:Real}}, right_window_sizes::Vector{<:Unitful.Energy{<:Real}}; kwargs...) = simple_calibration(e_uncal, th228_lines, [(l,r) for (l,r) in zip(left_window_sizes, right_window_sizes)],; kwargs...)
 
 
-function simple_calibration_th228(e_uncal::Vector{<:Real}, th228_lines::Vector{<:Unitful.Energy{<:Real}}, window_sizes::Vector{<:Tuple{Unitful.Energy{<:Real}, Unitful.Energy{<:Real}}},; n_bins::Int=15000, quantile_perc::Float64=NaN, binning_peak_window::Unitful.Energy{<:Real}=10.0u"keV")
-    # initial binning
-    bin_width = get_friedman_diaconis_bin_width(filter(in(quantile(e_uncal, 0.05)..quantile(e_uncal, 0.5)), e_uncal))
-    # create initial peak search histogram
-    h_uncal = fit(Histogram, e_uncal, 0:bin_width:maximum(e_uncal))
-    fep_guess = if isnan(quantile_perc)
-        # expect FEP in the last 10% of the data
-        min_e_fep = quantile(e_uncal, 0.9)
-        h_fepsearch = fit(Histogram, e_uncal, min_e_fep:bin_width:maximum(e_uncal))
-        # search all possible peak candidates
-        h_decon, peakpos = RadiationSpectra.peakfinder(h_fepsearch, σ=5.0, backgroundRemove=true, threshold=10)
-        # the FEP is the most prominent peak in the deconvoluted histogram
-        peakpos_idxs = StatsBase.binindex.(Ref(h_decon), peakpos)
-        cts_peakpos = h_decon.weights[peakpos_idxs]
-        peakpos[argmax(cts_peakpos)]
-    else
-        quantile(e_uncal, quantile_perc)
-    end
-    # get calibration constant for simple calibration
-    c = 2614.5*u"keV" / fep_guess
-    e_simple = e_uncal .* c
-    e_unit = u"keV"
+function simple_calibration_gamma(e_uncal::Vector{<:Real}, gamma_lines::Vector{<:Unitful.Energy{<:Real}}, window_sizes::Vector{<:Tuple{Unitful.Energy{<:Real}, Unitful.Energy{<:Real}}},; peaksearch_type::Symbol = :most_prominent, quantile_perc::Float64=NaN, binning_peak_window::Unitful.Energy{<:Real}=10.0u"keV", peakfinder_gamma::Int = 1, kwargs...)
+    if peaksearch_type == :most_prominent
+        # use most prominent peak in spectrum and use that one. This relies on the peakfinder to find all peaks in gamma_lines!
+       result_peak = peak_search_gamma(e_uncal, gamma_lines; kwargs...)
+   elseif peaksearch_type == :th228
+       # use Tl208FEP for Th228 calibration - value hardcoded for back compatibility
+       result_peak = peak_search_gamma(e_uncal, [2614.5*u"keV"]; kwargs...)
+   elseif peaksearch_type == :single
+       # use only 1 energy `gamma_lines[peaksearch_gamma]` in peak search
+       result_peak = peak_search_gamma(e_uncal, gamma_lines[peakfinder_gamma]; kwargs...)
+   end 
+    e_simple = e_uncal .* result_peak.c
+
     # get peakhists and peakstats
-    peakhists, peakstats, h_calsimple, bin_widths = get_peakhists_th228(e_simple, th228_lines, window_sizes; binning_peak_window=binning_peak_window, e_unit=e_unit)
+    peakhists, peakstats, h_calsimple, bin_widths = peakhists_gamma(e_simple, gamma_lines, window_sizes; binning_peak_window=binning_peak_window)
     
     result = (
         h_calsimple = h_calsimple, 
-        h_uncal = h_uncal, 
-        c = c,
+        h_uncal = result_peak.h_uncal, 
+        c = result_peak.c,
         unit = e_unit,
         bin_width = median(bin_widths),
-        fep_guess = fep_guess,
+        peak_guess = result_peak.peak_guess,
         peakbinwidths = bin_widths,
         peakhists = peakhists,
         peakstats = peakstats
@@ -74,7 +70,7 @@ function simple_calibration_th228(e_uncal::Vector{<:Real}, th228_lines::Vector{<
         h_calsimple = result.h_calsimple,
         h_uncal = result.h_uncal,
         c = result.c,
-        fep_guess = result.fep_guess,
+        peak_guess = result.peak_guess,
         peakhists = result.peakhists,
         peakstats = result.peakstats
     )
@@ -83,27 +79,84 @@ end
 
 
 """
-    get_peakhists_th228(e::Array, th228_lines::Array, window_sizes::Array, e_unit::String="keV", proxy_binning_peak::Float64=2103.5, proxy_binning_peak_window::Float64=10.0)
-
+    peakhists_gamma(e::Vector{<:Unitful.Energy{<:Real}}, gamma_lines::Vector{<:Unitful.Energy{<:Real}}, window_sizes::Vector{<:Tuple{Unitful.Energy{<:Real}, Unitful.Energy{<:Real}}},; binning_peak_window::Unitful.Energy{<:Real}=10.0u"keV")
 Create histograms around the calibration lines and return the histograms and the peak statistics.
-# Returns
+# input
+    * `e`: energy array
+    * `gamma_lines`: array of gamma lines
+    * `window_sizes`: array of tuples with left and right window sizes around the gamma lines
+## keyword Arguments:
+    * `binning_peak_window::Unitful.Energy{<:Real}`: energy window around each peak that is used to find optimal binning for peakhists
+# output
     * `peakhists`: array of histograms around the calibration lines
     * `peakstats`: array of statistics for the calibration line fits
 """
-function get_peakhists_th228(e::Vector{<:Unitful.Energy{<:Real}}, th228_lines::Vector{<:Unitful.Energy{<:Real}}, window_sizes::Vector{<:Tuple{Unitful.Energy{<:Real}, Unitful.Energy{<:Real}}},; e_unit::Unitful.EnergyUnits=u"keV", binning_peak_window::Unitful.Energy{<:Real}=10.0u"keV")
+function peakhists_gamma(e::Vector{<:Unitful.Energy{<:Real}}, gamma_lines::Vector{<:Unitful.Energy{<:Real}}, window_sizes::Vector{<:Tuple{Unitful.Energy{<:Real}, Unitful.Energy{<:Real}}},; binning_peak_window::Unitful.Energy{<:Real}=10.0u"keV")
     # get optimal binning for simple calibration
-    bin_widths = [get_friedman_diaconis_bin_width(filter(in(peak - binning_peak_window..peak + binning_peak_window), e)) for peak in th228_lines]
-    # Main.@infiltrate
+    bin_widths = [get_friedman_diaconis_bin_width(filter(in(peak - binning_peak_window..peak + binning_peak_window), e)) for peak in gamma_lines]
     # create histogram for simple calibration
     e_min, e_max = 0u"keV", 3000u"keV"
     h = fit(Histogram, ustrip.(e_unit, e), ustrip(e_unit, e_min):ustrip(e_unit, median(bin_widths)):ustrip(e_unit, e_max))
     # get histograms around calibration lines and peakstats
-    peakenergies = [ustrip.(e_unit, filter(in(peak - first(window)..peak + last(window)), e)) for (peak, window) in zip(th228_lines, window_sizes)]
+    peakenergies = [ustrip.(e_unit, filter(in(peak - first(window)..peak + last(window)), e)) for (peak, window) in zip(gamma_lines, window_sizes)]
     peakstats = StructArray(estimate_single_peak_stats.(peakenergies, ustrip.(e_unit, bin_widths)))
-    peakhists = [fit(Histogram, ustrip.(e_unit, e), ustrip(e_unit, peak - first(window)):ps.bin_width:ustrip(e_unit, peak + last(window))) for (peak, window, ps) in zip(Measurements.value.(th228_lines), window_sizes, peakstats)]
+    peakhists = [fit(Histogram, ustrip.(e_unit, e), ustrip(e_unit, peak - first(window)):ps.bin_width:ustrip(e_unit, peak + last(window))) for (peak, window, ps) in zip(Measurements.value.(gamma_lines), window_sizes, peakstats)]
     peakhists, peakstats, h, peakstats.bin_width .* e_unit
 end
-export get_peakhists_th228
+export peakhists_gamma
+peakhists_gamma(e, gamma_lines, left_window_sizes::Vector{<:Unitful.Energy{<:Real}}, right_window_sizes::Vector{<:Unitful.Energy{<:Real}}; kwargs...) = peakhists_gamma(e, gamma_lines, [(l,r) for (l,r) in zip(left_window_sizes, right_window_sizes)],; kwargs...)
 
-get_peakhists_th228(e, th228_lines, left_window_sizes::Vector{<:Unitful.Energy{<:Real}}, right_window_sizes::Vector{<:Unitful.Energy{<:Real}}; kwargs...) = get_peakhists_th228(e, th228_lines, [(l,r) for (l,r) in zip(left_window_sizes, right_window_sizes)],; kwargs...)
+"""
+     peak_search_gamma(e_uncal::Vector{<:Real}, gamma_lines::Vector{<:Unitful.Energy{<:Real}}; peakfinder_σ::Real = 2.0, peakfinder_threshold::Real = 10.0, peak_quantile::ClosedInterval{<:Real} = 0.0..1.0, bin_quantile::ClosedInterval{<:Real} = peak_quantile, quantile_perc::Float64=NaN) 
+peak search in gamma-ray spectrum
+# inputs:
+* `e_uncal`: uncalibrated energy array
+* `gamma_lines`: array of gamma lines
+* keyword arguments:
+        * `peakfinder_σ::Real=2.0`: The expected sigma of a peak in the spectrum. In units of bins. (see RadiationSpectra.peakfinder)
+        * `peakfinder_threshold::Real=10.0``: Threshold for being identified as a peak in the deconvoluted spectrum. A single bin is identified as an peak when its weight exceeds the threshold and the previous bin was not identified as an peak. (see RadiationSpectra.peakfinder)
+        * `peak_quantile::ClosedInterval{<:Real}=0.5..1.0`: quantiles that define energy window that is considered peak search (default: 0.0..1.0 == whole range). All `gamma_lines` have to be within this window.
+        * `bin_quantile::ClosedInterval{<:Real}=0.5..1.0`: quantiles that define energy window that is used to find optimal binning (default same as peak_quantile)
+        * `quantile_perc::Float64=NaN`: If NaN the standard peakfinder is used. If not NaN, the peak for simple calibration is set to given quantile energy. Useful for debugging/testing
+# output: `result` NamedTuple with the following fields:
+* `h_uncal`: histogram of the uncalibrated energy array with the binning that is used in peak search 
+* `c`: simple calibration factor
+* `peak_guess`: estimated peak energy in units of the uncalibrated energy array
+"""
+function peak_search_gamma(e_uncal::Vector{<:Real}, gamma_lines::Vector{<:Unitful.Energy{<:Real}}; peakfinder_σ::Real = 2.0, peakfinder_threshold::Real = 10.0, peak_quantile::ClosedInterval{<:Real} = 0.0..1.0, bin_quantile::ClosedInterval{<:Real} = peak_quantile, quantile_perc::Float64=NaN) 
+    # find optimal binning for peak search
+    bin_min = quantile(e_uncal, leftendpoint(bin_quantile))
+    bin_max = quantile(e_uncal, rightendpoint(bin_quantile))
+    bin_width = get_friedman_diaconis_bin_width(filter(in(bin_min..bin_max), e_uncal))
+    h_uncal = fit(Histogram, e_uncal, 0:bin_width:maximum(e_uncal)) # histogram over full energy range; stored for plot recipe 
 
+    peak_guess, peak_idx = if isnan(quantile_perc)
+        # create histogram for peak-search in peak-window
+        peak_min = quantile(e_uncal, leftendpoint(peak_quantile))
+        peak_max = quantile(e_uncal, rightendpoint(peak_quantile))
+        h_peaksearch = fit(Histogram, e_uncal, peak_min:bin_width:peak_max) # histogram for peak search
+
+        # search all possible peak candidates
+        @debug "debug: peakfinder_σ = $peakfinder_σ, peakfinder_threshold = $peakfinder_threshold"
+        @debug "debug: peak_quantile = $peak_quantile, bin_quantile = $bin_quantile"
+        h_decon, peakpos = RadiationSpectra.peakfinder(h_peaksearch, σ=peakfinder_σ, backgroundRemove = true, threshold = peakfinder_threshold)
+        # find the most prominent peak in the deconvoluted histogram
+        sort!(peakpos)
+        peakpos_idxs = StatsBase.binindex.(Ref(h_decon), peakpos)
+        cts_peakpos = h_decon.weights[peakpos_idxs]
+        @debug "Peaks found at $peakpos with intensity $cts_peakpos - literature values: $(gamma_lines)"
+        peakpos[argmax(cts_peakpos)], argmax(cts_peakpos)
+    else
+        quantile(e_uncal, quantile_perc), length(gamma_lines)
+    end
+    if length(gamma_lines) == 1 && peak_idx > 1
+        peak_idx = 1 # assume that most prominent peak is the one we are looking for
+    end
+    @debug "Identified most prominent peak at $(round(peak_guess, digits = 2)) - literature value: $(gamma_lines[peak_idx])"
+
+    # get calibration constant for simple calibration
+    c = gamma_lines[peak_idx] / peak_guess
+
+    result = (h_uncal = h_uncal, c = c, peak_guess = peak_guess)
+    return result
+end

--- a/src/simple_calibration.jl
+++ b/src/simple_calibration.jl
@@ -1,4 +1,3 @@
-const e_unit=u"keV" # unit for calibrated energies. All energy values will be convert to this unit
 """
     simple_calibration(e_uncal::Array, th228_lines::Array, window_size::Float64=25.0, n_bins::Int=15000, calib_type::String="th228")
 

--- a/src/simple_calibration.jl
+++ b/src/simple_calibration.jl
@@ -36,7 +36,7 @@ function simple_calibration(e_uncal::Vector{<:Real}, gamma_lines::Vector{<:Unitf
         error("Calibration type not supported")
     end
 end
-simple_calibration(e_uncal::Vector{<:Real}, gamma_lines::Vector{<:Unitful.Energy{<:Real}}, left_window_sizes::Vector{<:Unitful.Energy{<:Real}}, right_window_sizes::Vector{<:Unitful.Energy{<:Real}}; kwargs...) = simple_calibration(e_uncal, th228_lines, [(l,r) for (l,r) in zip(left_window_sizes, right_window_sizes)],; kwargs...)
+simple_calibration(e_uncal::Vector{<:Real}, gamma_lines::Vector{<:Unitful.Energy{<:Real}}, left_window_sizes::Vector{<:Unitful.Energy{<:Real}}, right_window_sizes::Vector{<:Unitful.Energy{<:Real}}; kwargs...) = simple_calibration(e_uncal, gamma_lines, [(l,r) for (l,r) in zip(left_window_sizes, right_window_sizes)],; kwargs...)
 
 
 function simple_calibration_gamma(e_uncal::Vector{<:Real}, gamma_lines::Vector{<:Unitful.Energy{<:Real}}, window_sizes::Vector{<:Tuple{Unitful.Energy{<:Real}, Unitful.Energy{<:Real}}},; peaksearch_type::Symbol = :most_prominent, binning_peak_window::Unitful.Energy{<:Real}=10.0u"keV", peakfinder_gamma::Int = 1, kwargs...)
@@ -145,8 +145,8 @@ function peak_search_gamma(e_uncal::Vector{<:Real}, gamma_lines::Vector{<:Unitfu
         peakpos_idxs = StatsBase.binindex.(Ref(h_decon), peakpos)
         cts_peakpos = h_decon.weights[peakpos_idxs]
         @debug "Peaks found at $peakpos with intensity $cts_peakpos - literature values: $(gamma_lines)"
-        if length(gamma_lines) != length(peakpos)
-            error("Number of gamma lines expected: $(length(gamma_lines)) vs. number of peaks foundL $(length(peak_guess)) -->  do not match \n try to adjust the peakfinder parameters: peakfinder_σ, peakfinder_threshold, or binning")
+        if length(gamma_lines) > 1 && (length(gamma_lines) != length(peakpos))
+            error("Number of gamma lines expected: $(length(gamma_lines)) vs. number of peaks found: $(length(peakpos)) -->  do not match \n try to adjust the peakfinder parameters: peakfinder_σ, peakfinder_threshold, or binning")
         end
         peakpos[argmax(cts_peakpos)], argmax(cts_peakpos)
     else
@@ -154,7 +154,8 @@ function peak_search_gamma(e_uncal::Vector{<:Real}, gamma_lines::Vector{<:Unitfu
     end
 
     if length(gamma_lines) == 1 && peak_idx > 1
-        peak_idx = 1 # assume that most prominent peak is the one we are looking for
+        @debug "Found more than one gamma lines - assume that  most prominent peak is the one we are looking for" 
+        peak_idx = 1 
     end
     @debug "Identified most prominent peak at $(round(peak_guess, digits = 2)) - literature value: $(gamma_lines[peak_idx])"
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -8,6 +8,7 @@ Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 
 [compat]
 Distributions = "0.25"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,5 +12,6 @@ Test.@testset "Package LegendSpecFits" begin
     include("test_docs.jl")
     include("test_lq.jl")
     include("test_aoe.jl")
+    include("test_simplecal.jl")
     isempty(Test.detect_ambiguities(LegendSpecFits))
 end # testset

--- a/test/test_simplecal.jl
+++ b/test/test_simplecal.jl
@@ -8,9 +8,10 @@ using StatsBase
 using Interpolations
 using Unitful 
 using IntervalSets
-include("test_utils.jl")
+# include("test_utils.jl")
 
 @testset "simplecal" begin
+    # Th228 
     # generate fake data - very simplified
     energy_test, th228_lines = generate_mc_spectrum(200000)
     m_cal_simple = 0.123u"keV"
@@ -18,15 +19,30 @@ include("test_utils.jl")
 
     # binning and peak-finder settings that should work for this fake data set 
     window_sizes =  vcat([(25.0u"keV",25.0u"keV") for _ in 1:6], (30.0u"keV",30.0u"keV"))
+    quantile_perc = 0.995
+  
+    # simple calibration
+    result_simple, report_simple = simple_calibration(e_uncal, th228_lines, window_sizes,; calib_type= :th228,  quantile_perc = quantile_perc);
+    @test isapprox(result_simple.c, m_cal_simple, atol = 0.05.*(m_cal_simple))
+
+
+    # Co60 
+    # generate fake data - very simplified
+    energy_test, co60_lines = generate_mc_spectrum_co60(200000)
+    m_cal_simple = 0.123u"keV"
+    e_uncal = energy_test ./ m_cal_simple
+
+    # binning and peak-finder settings that should work for this fake data set 
+    window_sizes =  vcat((25.0u"keV",25.0u"keV"), (30.0u"keV",30.0u"keV"))
     quantile_perc=NaN
     peakfinder_σ = 2.0
-    peakfinder_threshold = 6.0
-    peak_quantile = 0.7..1.0
-    bin_quantile =  0.05..0.5
+    peakfinder_threshold = 50.0
+    peak_quantile = 0.0..1.0
+    bin_quantile =  0.0..0.5
     quantile_perc = NaN 
-    kwargs = (peakfinder_σ=peakfinder_σ, peakfinder_threshold=peakfinder_threshold, peak_quantile=peak_quantile, bin_quantile=bin_quantile, quantile_perc = quantile_perc)
+    kwargs = (peaksearch_type = :most_prominent, peakfinder_σ=peakfinder_σ, peakfinder_threshold=peakfinder_threshold, peak_quantile=peak_quantile, bin_quantile=bin_quantile, quantile_perc = quantile_perc)
     
     # simple calibration
-    result_simple, report_simple = simple_calibration(e_uncal, th228_lines, window_sizes,; calib_type= :th228, kwargs...);
+    result_simple, report_simple = simple_calibration(e_uncal, co60_lines, window_sizes,; calib_type= :gamma, kwargs...);
     @test isapprox(result_simple.c, m_cal_simple, atol = 0.05.*(m_cal_simple))
 end

--- a/test/test_simplecal.jl
+++ b/test/test_simplecal.jl
@@ -1,0 +1,32 @@
+# This file is a part of LegendSpecFits.jl, licensed under the MIT License (MIT).
+using LegendSpecFits
+using Test
+using LegendDataTypes: fast_flatten
+using Measurements: value as mvalue
+using Distributions
+using StatsBase
+using Interpolations
+using Unitful 
+using IntervalSets
+include("test_utils.jl")
+
+@testset "simplecal" begin
+    # generate fake data - very simplified
+    energy_test, th228_lines = generate_mc_spectrum(200000)
+    m_cal_simple = 0.123u"keV"
+    e_uncal = energy_test ./ m_cal_simple
+
+    # binning and peak-finder settings that should work for this fake data set 
+    window_sizes =  vcat([(25.0u"keV",25.0u"keV") for _ in 1:6], (30.0u"keV",30.0u"keV"))
+    quantile_perc=NaN
+    peakfinder_σ = 2.0
+    peakfinder_threshold = 6.0
+    peak_quantile = 0.7..1.0
+    bin_quantile =  0.05..0.5
+    quantile_perc = NaN 
+    kwargs = (peakfinder_σ=peakfinder_σ, peakfinder_threshold=peakfinder_threshold, peak_quantile=peak_quantile, bin_quantile=bin_quantile, quantile_perc = quantile_perc)
+    
+    # simple calibration
+    result_simple, report_simple = simple_calibration(e_uncal, th228_lines, window_sizes,; calib_type= :th228, kwargs...);
+    @test isapprox(result_simple.c, m_cal_simple, atol = 0.05.*(m_cal_simple))
+end

--- a/test/test_specfit.jl
+++ b/test/test_specfit.jl
@@ -15,11 +15,11 @@ include("test_utils.jl")
     
     # simple calibration fit 
     window_sizes =  vcat([(25.0u"keV",25.0u"keV") for _ in 1:6], (30.0u"keV",30.0u"keV"))
-    result_simple, report_simple = simple_calibration(ustrip.(energy_test), th228_lines, window_sizes, n_bins=10000,; calib_type=:th228, quantile_perc=0.995)
+    result_simple, report_simple = simple_calibration(ustrip.(energy_test), th228_lines, window_sizes; calib_type=:th228, quantile_perc=0.995)
 
     # fit 
     result, report = fit_peaks(result_simple.peakhists, result_simple.peakstats, ustrip.(th228_lines),; uncertainty=true,calib_type = :th228, fit_func = [:gamma_def, :gamma_tails, :gamma_bckExp, :gamma_tails_bckFlat, :gamma_bckSlope, :gamma_minimal, :gamma_bckFlat]);
-    @test all([isapprox(mvalue(result[peak].µ), ustrip(th228_lines[i]), atol = 0.2*ustrip(th228_lines[i])) for (i, peak) in enumerate(keys(result))])
+    @test all([isapprox(mvalue(result[peak].µ), ustrip(th228_lines[i]), atol = 0.2*ustrip(th228_lines[i])) for (i, peak) in enumerate(sort!(Float64.(keys(result))))])
 end
 
 @testset "fit_subpeaks_th228" begin


### PR DESCRIPTION
- add a more generic simple_calibration function that can be accessed with keyword calib_type == :gamma which is useful for example for Co-60 data or other teststand data
- this is a more broken-down version of https://github.com/legend-exp/LegendSpecFits.jl/pull/108 (which will become obsolete with this PR)

- simple calibration report is plotable with modification in LegendMakie: https://github.com/legend-exp/LegendMakie.jl/pull/31/files 