### PR TITLE
Exclude `Plots` extension from codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,1 +1,3 @@
 # comment: false
+ignore:
+  - ext/LegendSpecFitsRecipesBaseExt.jl


### PR DESCRIPTION
A lot of untracked lines in codecov result from the `RecipesBase` extension to create plots with `Plots`.
To get a more realistic picture of the code coverage, I would exclude this extension from the codecov.