### PR TITLE
Reactivate tests on `pre`

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -27,8 +27,13 @@ jobs:
         run: julia -e 'using Pkg; Pkg.Registry.add("General"); Pkg.Registry.add(Pkg.RegistrySpec(url = "https://github.com/legend-exp/LegendJuliaRegistry"))'
         shell: bash
       - uses: julia-actions/julia-downgrade-compat@v1
+        if: matrix.version == 'pre'
+        with:
+          skip: Pkg,TOML,GaussianMixtures,Measurements,TypedTables,Unitful
+      - uses: julia-actions/julia-downgrade-compat@v1
+        if: matrix.version != 'pre'
         with:
           skip: Pkg,TOML,TypedTables
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-        continue-on-error: ${{ matrix.version == 'pre' }}
+        # continue-on-error: ${{ matrix.version == 'pre' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         run: julia add_registries.jl
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-        continue-on-error: ${{ matrix.version == 'pre' }}
+        # continue-on-error: ${{ matrix.version == 'pre' }}
         with:
           coverage: ${{ matrix.version == '1' && matrix.os == 'ubuntu-latest' && matrix.arch == 'x64' }}
       - uses: julia-actions/julia-processcoverage@v1


### PR DESCRIPTION
Now that a new version of `GaussianMixtures` was finally released, we can try reactivating the tests on julia-1.12 (`pre`)