### PR TITLE
sipm_simple_calibration: valley-based noise cut, noise threshold in result and report

### DIFF
--- a/src/sipm_simple_calibration.jl
+++ b/src/sipm_simple_calibration.jl
@@ -26,6 +26,15 @@ Returns
 function sipm_simple_calibration end
 export sipm_simple_calibration
 
+function sipm_simple_calibration(pe_uncal_vov::VectorOfVectors{<:Real}; initial_min_amp::Real=0.0, initial_max_amp::Real=50.0, relative_cut_noise_cut::Real=0.5, n_fwhm_noise_cut::Real=5.0, kwargs...)
+    pe_flat = filter(isfinite, reduce(vcat, pe_uncal_vov))
+    cuts_1pe = cut_single_peak(pe_flat, initial_min_amp, initial_max_amp, relative_cut=relative_cut_noise_cut)
+    noise_threshold = n_fwhm_noise_cut == 0.0 ? initial_min_amp : cuts_1pe.max + n_fwhm_noise_cut * (cuts_1pe.high - cuts_1pe.max)
+    pe_uncal = reduce(vcat, [trigs for trigs in pe_uncal_vov if count(t -> isfinite(t) && t > noise_threshold, trigs) == 1])
+    filter!(isfinite, pe_uncal)
+    return sipm_simple_calibration(pe_uncal; initial_min_amp=initial_min_amp, initial_max_amp=initial_max_amp, relative_cut_noise_cut=relative_cut_noise_cut, n_fwhm_noise_cut=n_fwhm_noise_cut, kwargs...)
+end
+
 function sipm_simple_calibration(pe_uncal::Vector{<:Real};
     min_pe_peak::Int=1, max_pe_peak::Int=5, relative_cut_noise_cut::Real=0.5, n_fwhm_noise_cut::Real=5.0,
     initial_min_amp::Real=0.0, initial_max_amp::Real=50.0, initial_max_bin_width_quantile::Real=0.9, 

--- a/src/sipm_simple_calibration.jl
+++ b/src/sipm_simple_calibration.jl
@@ -86,7 +86,8 @@ function sipm_simple_calibration(pe_uncal_vov::VectorOfVectors{<:Real};
         [t for trigs in pe_uncal_vov if length(trigs) ≤ cut_pool_max_mult
               for t in trigs if isfinite(t)]
     else
-        filter(isfinite, reduce(vcat, pe_uncal_vov))
+        # flatview is the flat backing vector of the VoV - linear, no pairwise vcat copies
+        filter(isfinite, flatview(pe_uncal_vov))
     end
     cuts_1pe = cut_single_peak(cut_pool, initial_min_amp, initial_max_amp, relative_cut=relative_cut_noise_cut)
     noise_threshold, valley_found = _find_noise_threshold(cut_pool, cuts_1pe, n_fwhm_noise_cut, initial_min_amp, initial_max_amp)

--- a/src/sipm_simple_calibration.jl
+++ b/src/sipm_simple_calibration.jl
@@ -37,7 +37,19 @@ function _find_noise_threshold(pe_data, cuts_1pe, n_fwhm_noise_cut, initial_min_
         _noise_hw = max(cuts_1pe.high - cuts_1pe.max, 0.1)
         _search_end = min(cuts_1pe.max + n_fwhm_noise_cut * _noise_hw, initial_max_amp)
         _h = fit(Histogram, filter(x -> cuts_1pe.high ≤ x ≤ _search_end, pe_data), cuts_1pe.high:_noise_hw:_search_end)
-        return length(_h.weights) > 0 ? _h.edges[1][argmin(_h.weights) + 1] : cuts_1pe.high
+        if length(_h.weights) == 0
+            return cuts_1pe.high
+        end
+        # find first local minimum: first bin where counts start rising again
+        _w = _h.weights
+        _min_idx = argmin(_w)
+        for i in 2:length(_w)
+            if _w[i] > _w[i-1]
+                _min_idx = i - 1
+                break
+            end
+        end
+        return _h.edges[1][_min_idx + 1]
     end
 end
 
@@ -122,6 +134,25 @@ function sipm_simple_calibration(pe_uncal::Vector{<:Real};
 
     # simple calibration
     sort!(peakpos)
+
+    # Merge close peaks for SiPM arrays with split PE peaks (e.g. multi-channel arrays)
+    # If sub-peaks of the same PE level are closer than 60% of the estimated gain, merge them
+    if length(peakpos) >= 3
+        _diffs = diff(peakpos)
+        _gain_est = maximum(_diffs)
+        _merged = [peakpos[1]]
+        for i in 2:length(peakpos)
+            if peakpos[i] - _merged[end] < 0.6 * _gain_est
+                _merged[end] = (_merged[end] + peakpos[i]) / 2
+            else
+                push!(_merged, peakpos[i])
+            end
+        end
+        if length(_merged) >= 2
+            peakpos = _merged
+        end
+    end
+
     @debug "Found $(min_pe_peak) PE Peak positions: $(peakpos[1])"
     @debug "Found $(min_pe_peak+1) PE Peak positions: $(peakpos[2])"
     gain = peakpos[2] - peakpos[1]

--- a/src/sipm_simple_calibration.jl
+++ b/src/sipm_simple_calibration.jl
@@ -26,10 +26,25 @@ Returns
 function sipm_simple_calibration end
 export sipm_simple_calibration
 
+# Auto-detect valley between noise peak and 1PE peak for positive n_fwhm_noise_cut,
+# keep original formula for negative values (include noise region)
+function _find_noise_threshold(pe_data, cuts_1pe, n_fwhm_noise_cut, initial_min_amp, initial_max_amp)
+    if n_fwhm_noise_cut == 0.0
+        return initial_min_amp
+    elseif n_fwhm_noise_cut < 0.0
+        return cuts_1pe.max + n_fwhm_noise_cut * (cuts_1pe.high - cuts_1pe.max)
+    else
+        _noise_hw = max(cuts_1pe.high - cuts_1pe.max, 0.1)
+        _search_end = min(cuts_1pe.max + n_fwhm_noise_cut * _noise_hw, initial_max_amp)
+        _h = fit(Histogram, filter(x -> cuts_1pe.high ≤ x ≤ _search_end, pe_data), cuts_1pe.high:_noise_hw:_search_end)
+        return length(_h.weights) > 0 ? StatsBase.midpoints(_h.edges[1])[argmin(_h.weights)] : cuts_1pe.high
+    end
+end
+
 function sipm_simple_calibration(pe_uncal_vov::VectorOfVectors{<:Real}; initial_min_amp::Real=0.0, initial_max_amp::Real=50.0, relative_cut_noise_cut::Real=0.5, n_fwhm_noise_cut::Real=5.0, kwargs...)
     pe_flat = filter(isfinite, reduce(vcat, pe_uncal_vov))
     cuts_1pe = cut_single_peak(pe_flat, initial_min_amp, initial_max_amp, relative_cut=relative_cut_noise_cut)
-    noise_threshold = n_fwhm_noise_cut == 0.0 ? initial_min_amp : cuts_1pe.max + n_fwhm_noise_cut * (cuts_1pe.high - cuts_1pe.max)
+    noise_threshold = _find_noise_threshold(pe_flat, cuts_1pe, n_fwhm_noise_cut, initial_min_amp, initial_max_amp)
     pe_uncal = reduce(vcat, [trigs for trigs in pe_uncal_vov if count(t -> isfinite(t) && t > noise_threshold, trigs) == 1])
     filter!(isfinite, pe_uncal)
     return sipm_simple_calibration(pe_uncal; initial_min_amp=initial_min_amp, initial_max_amp=initial_max_amp, relative_cut_noise_cut=relative_cut_noise_cut, n_fwhm_noise_cut=n_fwhm_noise_cut, kwargs...)
@@ -44,11 +59,7 @@ function sipm_simple_calibration(pe_uncal::Vector{<:Real};
     # Initial peak search
     cuts_1pe = cut_single_peak(pe_uncal, initial_min_amp, initial_max_amp, relative_cut=relative_cut_noise_cut)
     
-    bin_width_cut_min = if n_fwhm_noise_cut == 0.0
-        initial_min_amp
-    else
-        cuts_1pe.max+n_fwhm_noise_cut*(cuts_1pe.high - cuts_1pe.max)
-    end
+    bin_width_cut_min = _find_noise_threshold(pe_uncal, cuts_1pe, n_fwhm_noise_cut, initial_min_amp, initial_max_amp)
     bin_width_cut = get_friedman_diaconis_bin_width(filter(in(bin_width_cut_min..quantile(pe_uncal, initial_max_bin_width_quantile)), pe_uncal))
     peakpos = []
     for bin_width_scale in exp10.(range(0, stop=-3, length=10))

--- a/src/sipm_simple_calibration.jl
+++ b/src/sipm_simple_calibration.jl
@@ -2,116 +2,117 @@
     sipm_simple_calibration(pe_uncal::AbstractVector{<:Real})
     sipm_simple_calibration(pe_uncal_vov::VectorOfVectors{<:Real})
 
-Perform a simple calibration for the uncalibrated p.e. spectrum array `pe_uncal`
-using the 1 p.e. and 2 p.e. peak positions estimated by a peakfinder.
+Simple SiPM calibration from the 1 PE and 2 PE peak positions found by a
+peakfinder. The noise/1PE cut is auto-detected at the centroid of the first
+valley after the noise peak.
 
-The noise-1PE threshold is auto-detected as the first local minimum (valley) of
-the amplitude histogram between the noise peak and the upper search bound.
-`n_fwhm_noise_cut` caps the search window in units of the noise-peak
-half-width above its center; if no valley is found within this window, the
-window cap itself is returned (legacy FWHM formula). A value of `0.0` skips
-valley detection and uses `initial_min_amp` directly. Negative values force the
-legacy FWHM formula `cuts_1pe.max + n_fwhm_noise_cut * fwhm_noise` (kept for
-backward-compatibility with configs that intentionally dip into the noise peak).
+`n_fwhm_noise_cut` caps the valley search window in units of the noise-peak
+half-width above its center. `0.0` skips valley detection and uses
+`initial_min_amp`. Negative values force the legacy formula
+`cuts_1pe.max + n_fwhm_noise_cut * fwhm_noise` (kept for backward-compatibility
+with configs that dip into the noise peak).
 
-When called with a `VectorOfVectors{<:Real}` (per-waveform trigger amplitudes),
-an optional second-stage QC keeps only waveforms with exactly one trigger above
-the detected noise threshold (`single_trigger_only=true`, default). Set to
-`false` to use all triggers above threshold without per-waveform multiplicity
-filtering.
+For VoV input, an optional second-stage QC (`single_trigger_only=true`) keeps
+only waveforms with exactly one trigger above the detected threshold.
 
-Inputs:
-    * `pe_uncal`: vector of uncalibrated peak amplitudes, or VoV per-waveform
 kwargs:
-    * `initial_min_amp`, `initial_max_amp`: initial histogram bounds for the noise/peak search
-    * `relative_cut_noise_cut`: passed to `cut_single_peak` for the noise peak
+    * `initial_min_amp`, `initial_max_amp`: histogram bounds for the noise/peak search
+    * `relative_cut_noise_cut`: passed to `cut_single_peak`
     * `n_fwhm_noise_cut`: see above
-    * `single_trigger_only` (VoV only): if `true`, keep only single-trigger-above-threshold waveforms
+    * `single_trigger_only` (VoV only)
     * `min_pe_peak`, `max_pe_peak`, `peakfinder_*`: peakfinder controls
 
-Returns
-    * `result`: NamedTuple with `pe_simple_cal`, `peakpos`, `f_simple_calib`,
-      `f_simple_uncal`, `c`, `offset`, `noisepeakpos`, `noisepeakwidth`,
-      `noise_threshold`, `noise_threshold_cal`
-    * `report`: NamedTuple with `peakpos`, `peakpos_cal`, `h_uncal`,
-      `h_calsimple`, `noise_threshold`, `noise_threshold_cal`, `valley_found`
+Returns `(result, report)`. `result` carries the calibration (`f_simple_calib`,
+`c`, `offset`, `peakpos`, `noisepeakpos`, `noisepeakwidth`, `noise_threshold`,
+`noise_threshold_cal`). `report` carries plotting data (`peakpos*`, `h_uncal`,
+`h_calsimple`, `h_*_full` for the unfiltered all-trigger spectra,
+`noise_threshold*`, `valley_found`).
 """
 function sipm_simple_calibration end
 export sipm_simple_calibration
 
-# Auto-detect the *first* valley between the noise peak and the 1 PE peak.
-# Returns `(threshold, valley_found::Bool)`. Walks the smoothed histogram from
-# left to right and exits at the first local minimum that lies sufficiently
-# below the start of the search window — so multi-channel SiPMs with split 1PE
-# sub-peaks return the noise/sub-peak valley, not the deeper 1PE/2PE valley.
+# Detects the noise/1PE valley by walking a smoothed 40-bin histogram,
+# tracking the running minimum, and exiting once the curve clearly rises
+# again. The cut is placed at the centroid of the plateau at the minimum, so
+# wide empty valleys land mid-region rather than at the leftmost zero bin.
 function _find_noise_threshold(pe_data, cuts_1pe, n_fwhm_noise_cut, initial_min_amp, initial_max_amp)
-    if n_fwhm_noise_cut == 0.0
-        return initial_min_amp, false
-    elseif n_fwhm_noise_cut < 0.0
-        # Legacy: explicit FWHM formula, no valley search.
-        return cuts_1pe.max + n_fwhm_noise_cut * (cuts_1pe.high - cuts_1pe.max), false
-    end
+    n_fwhm_noise_cut == 0.0 && return initial_min_amp, false
+    n_fwhm_noise_cut < 0.0 && return cuts_1pe.max + n_fwhm_noise_cut * (cuts_1pe.high - cuts_1pe.max), false
+
     fwhm_noise = max(cuts_1pe.high - cuts_1pe.max, 0.1)
     search_end = min(cuts_1pe.max + n_fwhm_noise_cut * fwhm_noise, initial_max_amp)
-    if search_end ≤ cuts_1pe.high
-        return cuts_1pe.high, false
-    end
-    # ~40 bins across the search window — decoupled from the noise-peak width.
-    nbins = 40
-    edges = range(cuts_1pe.high, search_end; length=nbins + 1)
+    search_end ≤ cuts_1pe.high && return cuts_1pe.high, false
+
+    edges = range(cuts_1pe.high, search_end; length=41)
     h = fit(Histogram, filter(x -> cuts_1pe.high ≤ x ≤ search_end, pe_data), edges)
-    w = h.weights
-    sg_window = 5  # odd, ≥ degree + 1 for quadratic Savitzky–Golay
-    if length(w) < sg_window + 2
-        return search_end, false
-    end
-    # Smooth to suppress Poisson fluctuations on the falling noise tail.
-    w_s = savitzky_golay(w, sg_window, 2).y
-    # Depth gate: only accept a valley once we've descended to at most 50% of
-    # the start of the search window. The reference is the max of the first
-    # few bins to avoid being thrown by a single low first bin.
+    length(h.weights) < 7 && return search_end, false
+    w_s = savitzky_golay(h.weights, 5, 2).y
+
+    rise_factor = 1.5
     descent_threshold = 0.5 * maximum(@view w_s[1:min(3, length(w_s))])
-    for i in 2:length(w_s)-1
-        if w_s[i] ≤ descent_threshold && w_s[i] ≤ w_s[i-1] && w_s[i] < w_s[i+1]
-            return edges[i+1], true
+    running_min, running_min_idx, exit_idx = w_s[1], 1, 0
+    for i in 2:length(w_s)
+        if w_s[i] < running_min
+            running_min, running_min_idx = w_s[i], i
+        # `+ 2.0` floor handles near-empty valleys where `rise_factor * 0 == 0`.
+        elseif w_s[i] > max(rise_factor * running_min, running_min + 2.0) && running_min ≤ descent_threshold
+            exit_idx = i
+            break
         end
     end
-    return search_end, false
+    exit_idx == 0 && return search_end, false
+
+    # Centroid the cut over the bins from where `running_min` was first reached
+    # up to the rise — i.e. the actual flat region. Bins still on the descent
+    # before reaching `running_min` are excluded so the cut isn't biased left.
+    plateau_floor = max(rise_factor * running_min, running_min + 1.0)
+    plateau_idxs = findall(j -> w_s[j] ≤ plateau_floor, running_min_idx:exit_idx-1)
+    # Plateau too short → no real valley (e.g. noise tail blends into the 1PE
+    # rising flank). Fall back to N×FWHM above the noise peak.
+    length(plateau_idxs) < 4 && return cuts_1pe.max + 3.0 * fwhm_noise, false
+    idx = running_min_idx - 1 + (first(plateau_idxs) + last(plateau_idxs)) ÷ 2
+    return edges[idx + 1], true
 end
 
 function sipm_simple_calibration(pe_uncal_vov::VectorOfVectors{<:Real};
     initial_min_amp::Real=0.0, initial_max_amp::Real=50.0,
     relative_cut_noise_cut::Real=0.5, n_fwhm_noise_cut::Real=5.0,
-    single_trigger_only::Bool=true, kwargs...
+    single_trigger_only::Bool=true, cut_pool_max_mult::Int=3, kwargs...
 )
-    # Detect the noise threshold globally on the flat trigger distribution.
-    pe_flat = filter(isfinite, reduce(vcat, pe_uncal_vov))
-    cuts_1pe = cut_single_peak(pe_flat, initial_min_amp, initial_max_amp, relative_cut=relative_cut_noise_cut)
-    noise_threshold, valley_found = _find_noise_threshold(pe_flat, cuts_1pe, n_fwhm_noise_cut, initial_min_amp, initial_max_amp)
+    # Cut-detection pool: low-multiplicity waveforms (≤ `cut_pool_max_mult`
+    # triggers). Excludes heavily contaminated multi-trig waveforms while
+    # keeping enough statistics for the noise peak and valley to be visible.
+    cut_pool = if single_trigger_only
+        [t for trigs in pe_uncal_vov if length(trigs) ≤ cut_pool_max_mult
+              for t in trigs if isfinite(t)]
+    else
+        filter(isfinite, reduce(vcat, pe_uncal_vov))
+    end
+    cuts_1pe = cut_single_peak(cut_pool, initial_min_amp, initial_max_amp, relative_cut=relative_cut_noise_cut)
+    noise_threshold, valley_found = _find_noise_threshold(cut_pool, cuts_1pe, n_fwhm_noise_cut, initial_min_amp, initial_max_amp)
 
-    # Optional second-stage QC: keep only above-threshold triggers from waveforms
-    # with exactly one trigger above the noise threshold.
+    # Calibration pool: triggers from waveforms with exactly one trigger above
+    # the cut. Looser than 1-trig-total → more statistics for the peakfinder.
     pe_uncal = if single_trigger_only
         [t for trigs in pe_uncal_vov
               if count(t -> isfinite(t) && t > noise_threshold, trigs) == 1
               for t in trigs if isfinite(t) && t > noise_threshold]
     else
-        filter(x -> x > noise_threshold, pe_flat)
+        filter(x -> x > noise_threshold, cut_pool)
     end
 
-    # Threshold already applied → tell the Vector method to skip its own valley detection.
+    # Threshold already applied → skip the Vector method's own valley detection.
     result, report = sipm_simple_calibration(pe_uncal;
         initial_min_amp=noise_threshold, initial_max_amp=initial_max_amp,
         relative_cut_noise_cut=relative_cut_noise_cut, n_fwhm_noise_cut=0.0,
         kwargs...)
 
-    # Override the threshold/valley fields with the values detected at the VoV level.
     noise_threshold_cal = result.f_simple_calib(noise_threshold)
-    result = merge(result, (noise_threshold = noise_threshold,
-                            noise_threshold_cal = noise_threshold_cal))
-    report = merge(report, (noise_threshold = noise_threshold,
-                            noise_threshold_cal = noise_threshold_cal,
-                            valley_found = valley_found))
+    h_uncal_full = fit(Histogram, cut_pool, first(report.h_uncal.edges))
+    h_calsimple_full = fit(Histogram, result.f_simple_calib.(cut_pool), first(report.h_calsimple.edges))
+    result = merge(result, (; noise_threshold, noise_threshold_cal))
+    report = merge(report, (; noise_threshold, noise_threshold_cal, valley_found,
+                              h_uncal_full, h_calsimple_full))
     return result, report
 end
 
@@ -223,27 +224,14 @@ function sipm_simple_calibration(pe_uncal::Vector{<:Real};
     h_calsimple = fit(Histogram, pe_simple_cal, 0.0:bin_width_cal:max_pe_peak + 1)
     h_uncal = fit(Histogram, pe_uncal, 0.0:bin_width_uncal:f_simple_uncal(max_pe_peak + 1))
 
-    noise_threshold_cal = f_simple_calib(bin_width_cut_min)
-    result = (
-        pe_simple_cal = pe_simple_cal,
-        peakpos = peakpos,
-        f_simple_calib = f_simple_calib,
-        f_simple_uncal = f_simple_uncal,
-        c = c,
-        offset = offset,
-        noisepeakpos = cuts_1pe.max,
-        noisepeakwidth = cuts_1pe.high - cuts_1pe.low,
-        noise_threshold = bin_width_cut_min,
-        noise_threshold_cal = noise_threshold_cal,
-    )
-    report = (
-        peakpos = peakpos,
-        peakpos_cal = peakpos_cal,
-        h_uncal = h_uncal,
-        h_calsimple = h_calsimple,
-        noise_threshold = bin_width_cut_min,
-        noise_threshold_cal = noise_threshold_cal,
-        valley_found = valley_found,
-    )
+    noise_threshold = bin_width_cut_min
+    noise_threshold_cal = f_simple_calib(noise_threshold)
+    noisepeakpos, noisepeakwidth = cuts_1pe.max, cuts_1pe.high - cuts_1pe.low
+    result = (; pe_simple_cal, peakpos, f_simple_calib, f_simple_uncal, c, offset,
+                noisepeakpos, noisepeakwidth, noise_threshold, noise_threshold_cal)
+    # The VoV method overwrites `h_*_full` with the unfiltered all-trigger spectra.
+    report = (; peakpos, peakpos_cal, h_uncal, h_calsimple,
+                h_uncal_full = h_uncal, h_calsimple_full = h_calsimple,
+                noise_threshold, noise_threshold_cal, valley_found)
     return result, report
 end

--- a/src/sipm_simple_calibration.jl
+++ b/src/sipm_simple_calibration.jl
@@ -37,17 +37,19 @@ function _find_noise_threshold(pe_data, cuts_1pe, n_fwhm_noise_cut, initial_min_
         _noise_hw = max(cuts_1pe.high - cuts_1pe.max, 0.1)
         _search_end = min(cuts_1pe.max + n_fwhm_noise_cut * _noise_hw, initial_max_amp)
         _h = fit(Histogram, filter(x -> cuts_1pe.high ≤ x ≤ _search_end, pe_data), cuts_1pe.high:_noise_hw:_search_end)
-        return length(_h.weights) > 0 ? StatsBase.midpoints(_h.edges[1])[argmin(_h.weights)] : cuts_1pe.high
+        return length(_h.weights) > 0 ? _h.edges[1][argmin(_h.weights) + 1] : cuts_1pe.high
     end
 end
 
 function sipm_simple_calibration(pe_uncal_vov::VectorOfVectors{<:Real}; initial_min_amp::Real=0.0, initial_max_amp::Real=50.0, relative_cut_noise_cut::Real=0.5, n_fwhm_noise_cut::Real=5.0, kwargs...)
+    # 1. Find noise peak and valley on all triggers
     pe_flat = filter(isfinite, reduce(vcat, pe_uncal_vov))
     cuts_1pe = cut_single_peak(pe_flat, initial_min_amp, initial_max_amp, relative_cut=relative_cut_noise_cut)
     noise_threshold = _find_noise_threshold(pe_flat, cuts_1pe, n_fwhm_noise_cut, initial_min_amp, initial_max_amp)
-    pe_uncal = reduce(vcat, [trigs for trigs in pe_uncal_vov if count(t -> isfinite(t) && t > noise_threshold, trigs) == 1])
-    filter!(isfinite, pe_uncal)
-    return sipm_simple_calibration(pe_uncal; initial_min_amp=initial_min_amp, initial_max_amp=initial_max_amp, relative_cut_noise_cut=relative_cut_noise_cut, n_fwhm_noise_cut=n_fwhm_noise_cut, kwargs...)
+    # 2. Keep only above-threshold triggers from waveforms with exactly 1 trigger above threshold
+    pe_uncal = [t for trigs in pe_uncal_vov if count(t -> isfinite(t) && t > noise_threshold, trigs) == 1 for t in trigs if isfinite(t) && t > noise_threshold]
+    # 3. Pass to Vector method with noise cut already applied (n_fwhm_noise_cut=0, initial_min_amp=noise_threshold)
+    return sipm_simple_calibration(pe_uncal; initial_min_amp=noise_threshold, initial_max_amp=initial_max_amp, relative_cut_noise_cut=relative_cut_noise_cut, n_fwhm_noise_cut=0.0, kwargs...)
 end
 
 function sipm_simple_calibration(pe_uncal::Vector{<:Real};

--- a/src/sipm_simple_calibration.jl
+++ b/src/sipm_simple_calibration.jl
@@ -1,79 +1,129 @@
 """
-    sipm_simple_calibration(pe_uncal::Array)
+    sipm_simple_calibration(pe_uncal::AbstractVector{<:Real})
+    sipm_simple_calibration(pe_uncal_vov::VectorOfVectors{<:Real})
 
 Perform a simple calibration for the uncalibrated p.e. spectrum array `pe_uncal`
-using just the 1 p.e. and 2 p.e. peak positions estimated by a peakfinder.
+using the 1 p.e. and 2 p.e. peak positions estimated by a peakfinder.
+
+The noise-1PE threshold is auto-detected as the first local minimum (valley) of
+the amplitude histogram between the noise peak and the upper search bound.
+`n_fwhm_noise_cut` caps the search window in units of the noise-peak
+half-width above its center; if no valley is found within this window, the
+window cap itself is returned (legacy FWHM formula). A value of `0.0` skips
+valley detection and uses `initial_min_amp` directly. Negative values force the
+legacy FWHM formula `cuts_1pe.max + n_fwhm_noise_cut * fwhm_noise` (kept for
+backward-compatibility with configs that intentionally dip into the noise peak).
+
+When called with a `VectorOfVectors{<:Real}` (per-waveform trigger amplitudes),
+an optional second-stage QC keeps only waveforms with exactly one trigger above
+the detected noise threshold (`single_trigger_only=true`, default). Set to
+`false` to use all triggers above threshold without per-waveform multiplicity
+filtering.
 
 Inputs:
-    * `pe_uncal`: array of uncalibrated peak amplitudes
+    * `pe_uncal`: vector of uncalibrated peak amplitudes, or VoV per-waveform
 kwargs:
-    * `initial_min_amp`: uncalibrated amplitude value as a left boundary to build the uncalibrated histogram where the peak search is performed on.
-                        For the peak search with noise peak, this value is consecutively increased i.o.t exclude the noise peak from the histogram.
-    * `initial_max_quantile`: quantile of the uncalibrated amplitude array to used as right boundary to build the uncalibrated histogram
-    * `peakfinder_σ`: sigma value in number of bins for peakfinder
-    * `peakfinder_threshold`: threshold value for peakfinder
+    * `initial_min_amp`, `initial_max_amp`: initial histogram bounds for the noise/peak search
+    * `relative_cut_noise_cut`: passed to `cut_single_peak` for the noise peak
+    * `n_fwhm_noise_cut`: see above
+    * `single_trigger_only` (VoV only): if `true`, keep only single-trigger-above-threshold waveforms
+    * `min_pe_peak`, `max_pe_peak`, `peakfinder_*`: peakfinder controls
 
-Returns 
-    * `pe_simple_cal`: array of the calibrated pe array with the simple calibration
-    * `func`: function to use for the calibration (`pe_simple_cal = pe_uncal .* c .+ offset`)
-    * `c`: calibration factor
-    * `offset`: calibration offset 
-    * `peakpos`: 1 p.e. and 2 p.e. peak positions in uncalibrated amplitude
-    * `peakpos_cal`: 1 p.e. and 2 p.e. peak positions in calibrated amplitude
-    * `h_uncal`: histogram of the uncalibrated pe array
-    * `h_calsimple`: histogram of the calibrated pe array with the simple calibration
+Returns
+    * `result`: NamedTuple with `pe_simple_cal`, `peakpos`, `f_simple_calib`,
+      `f_simple_uncal`, `c`, `offset`, `noisepeakpos`, `noisepeakwidth`,
+      `noise_threshold`, `noise_threshold_cal`
+    * `report`: NamedTuple with `peakpos`, `peakpos_cal`, `h_uncal`,
+      `h_calsimple`, `noise_threshold`, `noise_threshold_cal`, `valley_found`
 """
 function sipm_simple_calibration end
 export sipm_simple_calibration
 
-# Auto-detect valley between noise peak and 1PE peak for positive n_fwhm_noise_cut,
-# keep original formula for negative values (include noise region)
+# Auto-detect the *first* valley between the noise peak and the 1 PE peak.
+# Returns `(threshold, valley_found::Bool)`. Walks the smoothed histogram from
+# left to right and exits at the first local minimum that lies sufficiently
+# below the start of the search window — so multi-channel SiPMs with split 1PE
+# sub-peaks return the noise/sub-peak valley, not the deeper 1PE/2PE valley.
 function _find_noise_threshold(pe_data, cuts_1pe, n_fwhm_noise_cut, initial_min_amp, initial_max_amp)
     if n_fwhm_noise_cut == 0.0
-        return initial_min_amp
+        return initial_min_amp, false
     elseif n_fwhm_noise_cut < 0.0
-        return cuts_1pe.max + n_fwhm_noise_cut * (cuts_1pe.high - cuts_1pe.max)
-    else
-        _noise_hw = max(cuts_1pe.high - cuts_1pe.max, 0.1)
-        _search_end = min(cuts_1pe.max + n_fwhm_noise_cut * _noise_hw, initial_max_amp)
-        _h = fit(Histogram, filter(x -> cuts_1pe.high ≤ x ≤ _search_end, pe_data), cuts_1pe.high:_noise_hw:_search_end)
-        if length(_h.weights) == 0
-            return cuts_1pe.high
-        end
-        # find first local minimum: first bin where counts start rising again
-        _w = _h.weights
-        _min_idx = argmin(_w)
-        for i in 2:length(_w)
-            if _w[i] > _w[i-1]
-                _min_idx = i - 1
-                break
-            end
-        end
-        return _h.edges[1][_min_idx + 1]
+        # Legacy: explicit FWHM formula, no valley search.
+        return cuts_1pe.max + n_fwhm_noise_cut * (cuts_1pe.high - cuts_1pe.max), false
     end
+    fwhm_noise = max(cuts_1pe.high - cuts_1pe.max, 0.1)
+    search_end = min(cuts_1pe.max + n_fwhm_noise_cut * fwhm_noise, initial_max_amp)
+    if search_end ≤ cuts_1pe.high
+        return cuts_1pe.high, false
+    end
+    # ~40 bins across the search window — decoupled from the noise-peak width.
+    nbins = 40
+    edges = range(cuts_1pe.high, search_end; length=nbins + 1)
+    h = fit(Histogram, filter(x -> cuts_1pe.high ≤ x ≤ search_end, pe_data), edges)
+    w = h.weights
+    sg_window = 5  # odd, ≥ degree + 1 for quadratic Savitzky–Golay
+    if length(w) < sg_window + 2
+        return search_end, false
+    end
+    # Smooth to suppress Poisson fluctuations on the falling noise tail.
+    w_s = savitzky_golay(w, sg_window, 2).y
+    # Depth gate: only accept a valley once we've descended to at most 50% of
+    # the start of the search window. The reference is the max of the first
+    # few bins to avoid being thrown by a single low first bin.
+    descent_threshold = 0.5 * maximum(@view w_s[1:min(3, length(w_s))])
+    for i in 2:length(w_s)-1
+        if w_s[i] ≤ descent_threshold && w_s[i] ≤ w_s[i-1] && w_s[i] < w_s[i+1]
+            return edges[i+1], true
+        end
+    end
+    return search_end, false
 end
 
-function sipm_simple_calibration(pe_uncal_vov::VectorOfVectors{<:Real}; initial_min_amp::Real=0.0, initial_max_amp::Real=50.0, relative_cut_noise_cut::Real=0.5, n_fwhm_noise_cut::Real=5.0, kwargs...)
-    # 1. Find noise peak and valley on all triggers
+function sipm_simple_calibration(pe_uncal_vov::VectorOfVectors{<:Real};
+    initial_min_amp::Real=0.0, initial_max_amp::Real=50.0,
+    relative_cut_noise_cut::Real=0.5, n_fwhm_noise_cut::Real=5.0,
+    single_trigger_only::Bool=true, kwargs...
+)
+    # Detect the noise threshold globally on the flat trigger distribution.
     pe_flat = filter(isfinite, reduce(vcat, pe_uncal_vov))
     cuts_1pe = cut_single_peak(pe_flat, initial_min_amp, initial_max_amp, relative_cut=relative_cut_noise_cut)
-    noise_threshold = _find_noise_threshold(pe_flat, cuts_1pe, n_fwhm_noise_cut, initial_min_amp, initial_max_amp)
-    # 2. Keep only above-threshold triggers from waveforms with exactly 1 trigger above threshold
-    pe_uncal = [t for trigs in pe_uncal_vov if count(t -> isfinite(t) && t > noise_threshold, trigs) == 1 for t in trigs if isfinite(t) && t > noise_threshold]
-    # 3. Pass to Vector method with noise cut already applied (n_fwhm_noise_cut=0, initial_min_amp=noise_threshold)
-    return sipm_simple_calibration(pe_uncal; initial_min_amp=noise_threshold, initial_max_amp=initial_max_amp, relative_cut_noise_cut=relative_cut_noise_cut, n_fwhm_noise_cut=0.0, kwargs...)
+    noise_threshold, valley_found = _find_noise_threshold(pe_flat, cuts_1pe, n_fwhm_noise_cut, initial_min_amp, initial_max_amp)
+
+    # Optional second-stage QC: keep only above-threshold triggers from waveforms
+    # with exactly one trigger above the noise threshold.
+    pe_uncal = if single_trigger_only
+        [t for trigs in pe_uncal_vov
+              if count(t -> isfinite(t) && t > noise_threshold, trigs) == 1
+              for t in trigs if isfinite(t) && t > noise_threshold]
+    else
+        filter(x -> x > noise_threshold, pe_flat)
+    end
+
+    # Threshold already applied → tell the Vector method to skip its own valley detection.
+    result, report = sipm_simple_calibration(pe_uncal;
+        initial_min_amp=noise_threshold, initial_max_amp=initial_max_amp,
+        relative_cut_noise_cut=relative_cut_noise_cut, n_fwhm_noise_cut=0.0,
+        kwargs...)
+
+    # Override the threshold/valley fields with the values detected at the VoV level.
+    noise_threshold_cal = result.f_simple_calib(noise_threshold)
+    result = merge(result, (noise_threshold = noise_threshold,
+                            noise_threshold_cal = noise_threshold_cal))
+    report = merge(report, (noise_threshold = noise_threshold,
+                            noise_threshold_cal = noise_threshold_cal,
+                            valley_found = valley_found))
+    return result, report
 end
 
 function sipm_simple_calibration(pe_uncal::Vector{<:Real};
     min_pe_peak::Int=1, max_pe_peak::Int=5, relative_cut_noise_cut::Real=0.5, n_fwhm_noise_cut::Real=5.0,
-    initial_min_amp::Real=0.0, initial_max_amp::Real=50.0, initial_max_bin_width_quantile::Real=0.9, 
+    initial_min_amp::Real=0.0, initial_max_amp::Real=50.0, initial_max_bin_width_quantile::Real=0.9,
     peakfinder_σ::Real=-1.0, peakfinder_threshold::Real=10.0, peakfinder_rtol::Real=0.1, peakfinder_α::Real=0.05
 )
-    
     # Initial peak search
     cuts_1pe = cut_single_peak(pe_uncal, initial_min_amp, initial_max_amp, relative_cut=relative_cut_noise_cut)
-    
-    bin_width_cut_min = _find_noise_threshold(pe_uncal, cuts_1pe, n_fwhm_noise_cut, initial_min_amp, initial_max_amp)
+
+    bin_width_cut_min, valley_found = _find_noise_threshold(pe_uncal, cuts_1pe, n_fwhm_noise_cut, initial_min_amp, initial_max_amp)
     bin_width_cut = get_friedman_diaconis_bin_width(filter(in(bin_width_cut_min..quantile(pe_uncal, initial_max_bin_width_quantile)), pe_uncal))
     peakpos = []
     for bin_width_scale in exp10.(range(0, stop=-3, length=10))
@@ -84,7 +134,7 @@ function sipm_simple_calibration(pe_uncal::Vector{<:Real};
             round(Int, 2*(cuts_1pe.high - cuts_1pe.max) / bin_width_cut_scaled / (2 * sqrt(2 * log(2))) )
         else
             isinteger(peakfinder_σ) || throw(ArgumentError("Expected `peakfinder_σ` to be an integer, but received $peakfinder_σ."))
-            round(Int, peakfinder_σ)  
+            round(Int, peakfinder_σ)
         end
         @debug "Peakfinder σ: $(peakfinder_σ_scaled)"
         try
@@ -108,7 +158,7 @@ function sipm_simple_calibration(pe_uncal::Vector{<:Real};
         @warn "Failed to find peaks with peakfinder method, use alternative"
         bin_width_cut_scaled = bin_width_cut * 0.5
         @debug "Using bin width: $(bin_width_cut_scaled)"
-        
+
         h_uncal_cut = fit(Histogram, pe_uncal, bin_width_cut_min:bin_width_cut_scaled:initial_max_amp)
         peakfinder_σ_scaled = if peakfinder_σ <= 0.0
             round(Int, 2*(cuts_1pe.high - cuts_1pe.max) / bin_width_cut_scaled / (2 * sqrt(2 * log(2))) )
@@ -116,14 +166,14 @@ function sipm_simple_calibration(pe_uncal::Vector{<:Real};
             isinteger(peakfinder_σ) || throw(ArgumentError("Expected `peakfinder_σ` to be an integer, but received $peakfinder_σ."))
             round(Int, peakfinder_σ)
         end
-        
+
         # use SavitzkyGolay filter to smooth the histogram
         sg_uncal_cut = savitzky_golay(h_uncal_cut.weights, ifelse(isodd(peakfinder_σ_scaled), peakfinder_σ_scaled, peakfinder_σ_scaled + 1), 3)
         edges = StatsBase.midpoints(first(h_uncal_cut.edges))  # use midpoints as x values
         counts_sg = sg_uncal_cut.y
         # get local maxima
         min_i_prominence = round(Int, peakfinder_σ_scaled / 2)
-        is_local_maximum(i, y) = i > min_i_prominence && i < length(y) - min_i_prominence && 
+        is_local_maximum(i, y) = i > min_i_prominence && i < length(y) - min_i_prominence &&
                 all(y[i] .> y[i-min_i_prominence:i-1]) && all(y[i] .> y[i+1:i+min_i_prominence])
         peakpos = edges[findall(is_local_maximum.(eachindex(counts_sg), Ref(counts_sg)))]
     end
@@ -135,21 +185,21 @@ function sipm_simple_calibration(pe_uncal::Vector{<:Real};
     # simple calibration
     sort!(peakpos)
 
-    # Merge close peaks for SiPM arrays with split PE peaks (e.g. multi-channel arrays)
-    # If sub-peaks of the same PE level are closer than 60% of the estimated gain, merge them
+    # Merge close peaks for SiPM arrays with split PE peaks (e.g. multi-channel arrays):
+    # if adjacent peaks are closer than 60% of the estimated gain, fold them into one.
     if length(peakpos) >= 3
-        _diffs = diff(peakpos)
-        _gain_est = maximum(_diffs)
-        _merged = [peakpos[1]]
+        diffs = diff(peakpos)
+        gain_est = maximum(diffs)
+        merged = [peakpos[1]]
         for i in 2:length(peakpos)
-            if peakpos[i] - _merged[end] < 0.6 * _gain_est
-                _merged[end] = (_merged[end] + peakpos[i]) / 2
+            if peakpos[i] - merged[end] < 0.6 * gain_est
+                merged[end] = (merged[end] + peakpos[i]) / 2
             else
-                push!(_merged, peakpos[i])
+                push!(merged, peakpos[i])
             end
         end
-        if length(_merged) >= 2
-            peakpos = _merged
+        if length(merged) >= 2
+            peakpos = merged
         end
     end
 
@@ -166,13 +216,14 @@ function sipm_simple_calibration(pe_uncal::Vector{<:Real};
 
     pe_simple_cal = f_simple_calib.(pe_uncal)
     peakpos_cal = f_simple_calib.(peakpos)
-    
+
     bin_width_cal = get_friedman_diaconis_bin_width(filter(in(0.5..min_pe_peak), pe_simple_cal))
     bin_width_uncal = f_simple_uncal(bin_width_cal) - f_simple_uncal(0.0)
 
     h_calsimple = fit(Histogram, pe_simple_cal, 0.0:bin_width_cal:max_pe_peak + 1)
     h_uncal = fit(Histogram, pe_uncal, 0.0:bin_width_uncal:f_simple_uncal(max_pe_peak + 1))
 
+    noise_threshold_cal = f_simple_calib(bin_width_cut_min)
     result = (
         pe_simple_cal = pe_simple_cal,
         peakpos = peakpos,
@@ -181,13 +232,18 @@ function sipm_simple_calibration(pe_uncal::Vector{<:Real};
         c = c,
         offset = offset,
         noisepeakpos = cuts_1pe.max,
-        noisepeakwidth = cuts_1pe.high - cuts_1pe.low
+        noisepeakwidth = cuts_1pe.high - cuts_1pe.low,
+        noise_threshold = bin_width_cut_min,
+        noise_threshold_cal = noise_threshold_cal,
     )
     report = (
         peakpos = peakpos,
         peakpos_cal = peakpos_cal,
-        h_uncal = h_uncal, 
-        h_calsimple = h_calsimple
+        h_uncal = h_uncal,
+        h_calsimple = h_calsimple,
+        noise_threshold = bin_width_cut_min,
+        noise_threshold_cal = noise_threshold_cal,
+        valley_found = valley_found,
     )
     return result, report
 end


### PR DESCRIPTION
## What didn't work before
The noise/1PE cut of `sipm_simple_calibration` was a fixed offset above the noise peak
(`cuts_1pe.max + n_fwhm_noise_cut * fwhm_noise`). On channels where the noise tail blends
into the 1PE peak, or where the valley is wide and empty, that cut landed inside the noise
or the 1PE peak, the peak search then locked onto the wrong maximum, and the threshold that
was actually used was not part of the result — so it could neither be stored nor plotted.

## What works now
- **Valley detection:** the noise/1PE threshold is found at the centroid of the first valley
  after the noise peak on a smoothed 40-bin histogram (`_find_noise_threshold`);
  `n_fwhm_noise_cut` caps the search window in units of the noise-peak half-width,
  `0.0` skips detection (uses `initial_min_amp`), negative values keep the legacy formula.
  Split 1PE peaks are merged before the peak search.
- **Peak search:** the left window starts at the minimum after the noise peak; trigger logic
  for the VoV input reworked, optional `single_trigger_only` second-stage QC keeps only
  waveforms with exactly one trigger above the detected threshold.
- **Result / report:** `result` gains `noise_threshold` and `noise_threshold_cal`; `report`
  gains `noise_threshold*`, `valley_found` and the unfiltered all-trigger spectra
  `h_uncal_full` / `h_calsimple_full` for plotting.
- **Perf:** the cut pool is built with `flatview` instead of pairwise `vcat`.

## Downstream
LegendMakie recipe (composite plot with the noise cut marker) and Juleana (persist the
threshold per detector in the SiPM pars) — PRs linked below.
