### PR TITLE
fit_single_trunc_gauss: bounded histogram range, clear error on degenerate input, units in every branch

### DIFF
--- a/src/singlefit.jl
+++ b/src/singlefit.jl
@@ -16,6 +16,8 @@ function fit_single_trunc_gauss(x::Vector{<:Unitful.RealOrRealQuantity}, cuts::N
     cut_low, cut_high = ifelse(isnan(cut_low), minimum(x), cut_low), ifelse(isnan(cut_high), maximum(x), cut_high)
 
     bin_width = get_friedman_diaconis_bin_width(x[cut_low .<= x .<= cut_high])
+    # degenerate input (single value or fits piling up on one value) cannot be binned
+    bin_width > 0 || throw(ArgumentError("degenerate distribution in ($(cut_low*x_unit), $(cut_high*x_unit)): IQR = 0 over $(count(cut_low .<= x .<= cut_high)) entries"))
     # bound the range: single diverging outliers (e.g. tail-fit τ → ±Inf) would explode the bin count
     x_min, x_max = max(minimum(x), cut_low - 100*bin_width), min(maximum(x), cut_high + 100*bin_width)
     x_nocut = copy(x)

--- a/src/singlefit.jl
+++ b/src/singlefit.jl
@@ -102,7 +102,8 @@ function fit_single_trunc_gauss(x::Vector{<:Unitful.RealOrRealQuantity}, cuts::N
         @debug "μ: $(v_ml.μ)"
         @debug "σ: $(v_ml.σ)"
 
-        result = merge(v_ml, )
+        # attach units like the uncertainty branch does — callers get a consistent API
+        result = NamedTuple{keys(v_ml)}([v_ml[k] * x_unit for k in keys(v_ml)])
     end
 
     # create histogram of nocut data for normalization 20 sigma around peak

--- a/src/singlefit.jl
+++ b/src/singlefit.jl
@@ -16,7 +16,8 @@ function fit_single_trunc_gauss(x::Vector{<:Unitful.RealOrRealQuantity}, cuts::N
     cut_low, cut_high = ifelse(isnan(cut_low), minimum(x), cut_low), ifelse(isnan(cut_high), maximum(x), cut_high)
 
     bin_width = get_friedman_diaconis_bin_width(x[cut_low .<= x .<= cut_high])
-    x_min, x_max = extrema(x)
+    # bound the range: single diverging outliers (e.g. tail-fit τ → ±Inf) would explode the bin count
+    x_min, x_max = max(minimum(x), cut_low - 100*bin_width), min(maximum(x), cut_high + 100*bin_width)
     x_nocut = copy(x)
     h_nocut = fit(Histogram, x, x_min:bin_width:x_max)
     ps = estimate_single_peak_stats_simple(h_nocut)


### PR DESCRIPTION
Three robustness fixes in `singlefit.jl`, decay-time / A/E steps:
- the no-cut histogram range is bounded to `cut ± 100 bin widths` — a single diverging
  outlier (e.g. a tail-fit τ → ±Inf) used to explode the bin count and the memory;
- degenerate input (IQR = 0, everything piles up on one value) fails with an `ArgumentError`
  naming the window and the count instead of an obscure binning error;
- the non-converged branch attaches units like the converged one, so callers get a consistent
  result (`DimensionError` downstream before).
