### PR TITLE
Fits must not crash or hang on states the optimizer only probes: poisson_binll, estimate_fwhm scan cap

### DIFF
--- a/src/gof.jl
+++ b/src/gof.jl
@@ -74,7 +74,7 @@ function p_value_poissonll(fit_func::Base.Callable, h::Histogram{<:Real,1}, v_ml
     counts, bin_widths, bin_centers = _prepare_data(h) # prepare data
     model_func = Base.Fix2(fit_func, v_ml) # fix the fit parameters to ML best-estimate
 
-    bin_ll(x, bw, k) = logpdf(Poisson(bw * model_func(x)), k) # loglikelihood per bin, evaluated for best-fit parameters (v_ml)
+    bin_ll(x, bw, k) = poisson_binll(bw * model_func(x), k) # loglikelihood per bin, evaluated for best-fit parameters (v_ml)
     loglikelihood_ml = sum(Base.Broadcast.broadcasted(bin_ll, bin_centers, bin_widths, counts)) # joint loglikelihood, evaluated for best-fit parameters (v_ml)
 
     loglikelihood_null = sum(logpdf.(Poisson.(counts), counts))  # joint loglikelihood, evaluate for data only
@@ -98,7 +98,7 @@ function likelihood_ratio(f_fit::Base.Callable, h::Histogram{<:Real,1})
     counts = h.weights
     bin_centers = (bin_edges[begin:end-1] .+ bin_edges[begin+1:end]) ./ 2
     bin_widths = bin_edges[begin+1:end] .- bin_edges[begin:end-1]
-    bin_ll(x, bw, k) = logpdf(Poisson(bw * f_fit(x)), k)
+    bin_ll(x, bw, k) = poisson_binll(bw * f_fit(x), k)
     loglikelihood_ml = sum(Base.Broadcast.broadcasted(bin_ll, bin_centers, bin_widths, counts))
     loglikelihood = sum(logpdf.(Poisson.(counts), counts))
     -2*(loglikelihood_ml - loglikelihood)

--- a/src/likelihoods.jl
+++ b/src/likelihoods.jl
@@ -2,6 +2,15 @@
 
 
 """
+    poisson_binll(λ::Real, k::Real)
+
+Poisson log-likelihood of `k` counts for expectation `λ`; `-Inf` (instead of a `DomainError`)
+for negative or non-finite `λ`, which the optimizer probes but must reject.
+"""
+poisson_binll(λ::Real, k::Real) = isfinite(λ) && λ >= zero(λ) ? logpdf(Poisson(λ), k) : oftype(float(λ), -Inf)
+
+
+"""
     hist_loglike(f_fit::Base.Callable, h::Histogram{<:Real,1})
 
 Calculate the Poisson log-likelihood of a fit function `f_fit(x)` and a
@@ -16,8 +25,8 @@ function hist_loglike(f_fit::Base.Callable, h::Histogram{<:Real,1})
     counts = h.weights
     bin_centers = midpoints(bin_edges)
     bin_widths = diff(bin_edges)
-    # TODO: Prevent fit functions from returning negative PDF values 
-    bin_ll(x, bw, k) = logpdf(Poisson(bw * f_fit(x)), k)
+    # TODO: prevent fit functions from returning negative PDF values in the first place
+    bin_ll(x, bw, k) = poisson_binll(bw * f_fit(x), k)
     sum(Base.Broadcast.broadcasted(bin_ll, bin_centers, bin_widths, counts))
 end
 export hist_loglike

--- a/src/specfit.jl
+++ b/src/specfit.jl
@@ -217,9 +217,12 @@ function estimate_fwhm(v::NamedTuple)
         f_sigWithTail = Base.Fix2(get_th228_fit_functions().gamma_sigWithTail,v)
         try
             e_low, e_high = v.skew_fraction <= 0.5 ? (v.μ - v.σ, v.μ + v.σ) : (v.μ * (1 - v.skew_width), v.μ * (1 + v.skew_width))
-            
+
+            # cap the scan at 1e5 steps - a huge MC σ would otherwise make this loop run for hours
+            step = max(0.001, (e_high - e_low) / 100_000)
+
             max_sig = -Inf
-            for e in e_low:0.001:e_high
+            for e in e_low:step:e_high
                 fe = f_sigWithTail(e)
                 if fe > max_sig
                     max_sig = fe


### PR DESCRIPTION
- **`poisson_binll(λ, k)`** (new, used in the likelihoods and in `gof`): returns `-Inf` for
  negative or non-finite `λ` instead of throwing. During a fit the optimizer routinely
  probes parameter sets with a negative or NaN model density (negative background amplitude,
  width → 0); their log-likelihood is `-Inf` and the optimizer moves on, whereas
  `Poisson(λ)` raised a `DomainError` that aborted the whole fit.
- **`estimate_fwhm`**: the FWHM scan step is `max(1e-3, range/1e5)` — an MC draw of the fit
  parameters with a huge σ made the fixed 1e-3 scan run for hours (this was the hanging
  ecal step in the production); physical widths keep the 1e-3 step exactly.
