### PR TITLE
Better error and debug messages

### DIFF
--- a/src/aoe_filter_optimization.jl
+++ b/src/aoe_filter_optimization.jl
@@ -61,6 +61,8 @@ function fit_sf_wl(e_dep::Vector{<:Real}, aoe_dep::ArrayOfSimilarArrays{<:Real},
     fts_success = Bool.(zeros(length(a_grid_wl_sg)))
     sep_sfs = Vector{Quantity}(undef, length(a_grid_wl_sg))
     wls = Vector{eltype(a_grid_wl_sg)}(undef, length(a_grid_wl_sg))
+    # per-gridpoint failure reason, surfaced in the error message if the scan comes up empty
+    skip_reason = fill("", length(a_grid_wl_sg))
 
     # for each window lenght, calculate the survival fraction in the SEP
     Threads.@threads for i_aoe in eachindex(a_grid_wl_sg)
@@ -90,6 +92,7 @@ function fit_sf_wl(e_dep::Vector{<:Real}, aoe_dep::ArrayOfSimilarArrays{<:Real},
             fts_success[i_aoe] = true
         catch e
             @warn "Couldn't process window length $wl"
+            skip_reason[i_aoe] = first(sprint(showerror, e), 80)
         end
         yield()
     end
@@ -98,11 +101,14 @@ function fit_sf_wl(e_dep::Vector{<:Real}, aoe_dep::ArrayOfSimilarArrays{<:Real},
     sep_sfs = sep_sfs[fts_success]
     wls = wls[fts_success]
 
-    # get minimal survival fraction and window length
+    # get minimal survival fraction and window length; a single point is no optimization (report consumers assume a grid)
     sep_sfs_cut = 1.0u"percent" .< sep_sfs .< 100u"percent"
-    if isempty(sep_sfs[sep_sfs_cut])
+    if count(sep_sfs_cut) < 2
+        reasons = join(["$(count(==(r), skip_reason))x $r" for r in unique(filter(!isempty, skip_reason))], ", ")
         @error "No valid SEP SF found"
-        throw(ErrorException("No valid SF found, could not determine optimal window length"))
+        throw(ErrorException("only $(count(sep_sfs_cut)) of $(length(a_grid_wl_sg)) window-length grid points gave a valid SF " *
+            "($(count(.!sep_sfs_cut))x SF outside (1, 100) %$(isempty(reasons) ? "" : ", " * reasons)) — at least 2 required; " *
+            "check DEP/SEP statistics of this channel; a det-specific override or aoe status change may be needed"))
     end
     min_sf       = minimum(sep_sfs[sep_sfs_cut])
     wl_sg_min_sf = wls[sep_sfs_cut][findmin(sep_sfs[sep_sfs_cut])[2]]

--- a/src/filter_optimization.jl
+++ b/src/filter_optimization.jl
@@ -131,6 +131,8 @@ function _fit_fwhm_ft(e_grid::Matrix, e_grid_ft::StepRangeLen, rt::Unitful.RealO
     fwhm = Vector{Measurement}(undef, length(e_grid_ft))
     modes = Vector{Float64}(undef, length(e_grid_ft))
     fts_success  = Bool.(zeros(length(e_grid_ft)))
+    # per-gridpoint skip reason, surfaced in the error message if no point survives
+    skip_reason  = fill("", length(e_grid_ft))
     
     Threads.@threads for f in eachindex(e_grid_ft)
         # get ft
@@ -153,6 +155,7 @@ function _fit_fwhm_ft(e_grid::Matrix, e_grid_ft::StepRangeLen, rt::Unitful.RealO
         # create histogram from it
         if isempty(e_ft)
             @debug "Invalid energy vector, skipping"
+            skip_reason[f] = "empty peak-cut energy vector"
             continue
         end
         bin_width = 2 * (quantile(e_ft, 0.75) - quantile(e_ft, 0.25)) / ∛(length(e_ft))
@@ -163,6 +166,7 @@ function _fit_fwhm_ft(e_grid::Matrix, e_grid_ft::StepRangeLen, rt::Unitful.RealO
         # check if ps guess is valid
         if any(tuple_to_array(ps) .<= 0)
             @debug "Invalid guess for peakstats, skipping"
+            skip_reason[f] = "invalid peak-stats guess (smeared/missing peak)"
             continue
         end
         # fit peak 
@@ -182,7 +186,7 @@ function _fit_fwhm_ft(e_grid::Matrix, e_grid_ft::StepRangeLen, rt::Unitful.RealO
     # get minimal fwhm and rt
     if isempty(fwhm)
         @error "No valid FWHM found."
-        throw(ErrorException("No valid FWHM found, could not determine optimal FT"))
+        throw(ErrorException("No valid FWHM on any of the $(length(e_grid_ft)) FT grid points ($(join(["$(count(==(r), skip_reason))x $r" for r in unique(filter(!isempty, skip_reason))], ", "))) — check the FEP peak shape of this channel; a det-specific optimization override or usability change may be needed"))
     else
         # calibration constant from mean of modes
         c = peak ./ mean(modes)
@@ -236,6 +240,8 @@ function _fit_fwhm_ft_ctc(e_grid::Matrix, e_grid_ft::StepRangeLen, qdrift::Vecto
     fwhm = Vector{Measurement}(undef, length(e_grid_ft))
     modes = Vector{Float64}(undef, length(e_grid_ft))
     fts_success  = Bool.(zeros(length(e_grid_ft)))
+    # per-gridpoint skip reason, surfaced in the error message if no point survives
+    skip_reason  = fill("", length(e_grid_ft))
     
     Threads.@threads for f in eachindex(e_grid_ft)
         # get ft
@@ -267,6 +273,7 @@ function _fit_fwhm_ft_ctc(e_grid::Matrix, e_grid_ft::StepRangeLen, qdrift::Vecto
         # check if ps guess is valid
         if any(tuple_to_array(ps) .<= 0)
             @debug "Invalid guess for peakstats, skipping"
+            skip_reason[f] = "invalid peak-stats guess (smeared/missing peak)"
             continue
         end
         # fit peak
@@ -287,7 +294,7 @@ function _fit_fwhm_ft_ctc(e_grid::Matrix, e_grid_ft::StepRangeLen, qdrift::Vecto
     # get minimal fwhm and rt
     if isempty(fwhm)
         @error "No valid FWHM found."
-        throw(ErrorException("No valid FWHM found, could not determine optimal FT"))
+        throw(ErrorException("No valid FWHM on any of the $(length(e_grid_ft)) FT grid points ($(join(["$(count(==(r), skip_reason))x $r" for r in unique(filter(!isempty, skip_reason))], ", "))) — check the FEP peak shape of this channel; a det-specific optimization override or usability change may be needed"))
     else
         # calibration constant from mean of modes
         c = peak ./ mean(modes)

--- a/src/filter_optimization.jl
+++ b/src/filter_optimization.jl
@@ -145,6 +145,7 @@ function _fit_fwhm_ft(e_grid::Matrix, e_grid_ft::StepRangeLen, rt::Unitful.RealO
         # sanity check
         if count(min_e .< e_ft .< max_e) < 100
             @debug "Not enough data points for FT $ft, skipping"
+            skip_reason[f] = "fewer than 100 events in the (min_e, max_e) window"
             continue
         end
         # cut around peak to increase performance
@@ -256,6 +257,7 @@ function _fit_fwhm_ft_ctc(e_grid::Matrix, e_grid_ft::StepRangeLen, qdrift::Vecto
         # sanity check
         if count(min_e .< e_ft .< max_e) < 100
             @debug "Not enough data points for FT $ft, skipping"
+            skip_reason[f] = "fewer than 100 events in the (min_e, max_e) window"
             continue
         end
         # cut around peak to increase performance

--- a/src/fit_calibration.jl
+++ b/src/fit_calibration.jl
@@ -9,9 +9,17 @@ Fit the calibration lines with polynomial function of pol_order order
         * `gof`: godness of fit
     * `report`: 
 """
+# an empty peak list (nothing passed the fit QC) arrives as an untyped Vector{Any} - fail readably
+function fit_calibration(pol_order::Int, µ::AbstractVector, peaks::AbstractVector; kwargs...)
+    isempty(µ) && throw(ArgumentError("calibration fit needs at least one peak position - no peak passed the fit QC"))
+    throw(MethodError(fit_calibration, (pol_order, µ, peaks)))
+end
+
 function fit_calibration(pol_order::Int, µ::AbstractVector{<:Union{Unitful.RealOrRealQuantity,Measurement{<:Unitful.RealOrRealQuantity}}}, peaks::AbstractVector{<:Quantity}; e_expression::Union{Symbol, String}="e", m_cal_simple::Union{MaybeWithEnergyUnits, Nothing} = nothing, uncertainty::Bool=true)
     @assert length(peaks) == length(μ) "Number of calibration points does not match the number of energies"
     @assert pol_order >= 1 "The polynomial order must be greater than 0"
+    # empty typed vectors (Vector{Union{}} from an empty comprehension) pass the untyped guard
+    isempty(µ) && throw(ArgumentError("calibration fit needs at least one peak position - no peak passed the fit QC"))
 
     e_unit = unit(first(peaks))
     # make all inputs unitless with the dimension e_unit

--- a/src/fit_fwhm.jl
+++ b/src/fit_fwhm.jl
@@ -13,7 +13,9 @@ export fit_fwhm
 function fit_fwhm(pol_order::Int, peaks::Vector{<:Unitful.Energy{<:Real}}, fwhm::Vector{<:Unitful.Energy{<:Real}}; e_type_cal::Symbol=:e_cal, e_expression::Union{Symbol, String}="e", uncertainty::Bool=true)
     @assert length(peaks) == length(fwhm) "Peaks and FWHM must have the same length"
     @assert pol_order >= 1 "The polynomial order must be greater than 0"
-    
+    # needs pol_order+1 points and the intercept guess uses the first two (BoundsError with a single peak)
+    length(peaks) >= max(2, pol_order + 1) || throw(ArgumentError("FWHM fit with pol_order $pol_order needs at least $(max(2, pol_order + 1)) peaks, got $(length(peaks)) - not enough peaks passed the fit QC"))
+
     # fit FWHM fit function
     _linear_intercept(x1::Float64, x2::Float64, y1::Float64, y2::Float64) = y1 - ((y2 - y1) / (x2 - x1)) * x1
     intercept_first_two_points = _linear_intercept(mvalue.(ustrip.(e_unit,sort(peaks)[1:2]))..., mvalue.(ustrip.(e_unit, fwhm[sortperm(peaks)[1:2]]))...)

--- a/src/peakstats.jl
+++ b/src/peakstats.jl
@@ -80,6 +80,8 @@ function estimate_single_peak_stats_th228(h::Histogram{T}) where T<:Real
         peak_fwhm = 2.0
     end
     # peak_area = peak_amplitude * peak_sigma * sqrt(2*π)
+    # the 7-bin sidebands overlap the peak (and underflow) with <= 14 bins - fail with a speaking error
+    length(W) > 14 || throw(ArgumentError("peak histogram has only $(length(W)) bins - too few events in the peak window for a background estimate"))
     # calculate mean background and step
     idx_bkg_left = something(findfirst(x -> x >= peak_pos - 15*peak_sigma, E[2:end]), 7)
     idx_bkg_right = something(findfirst(x -> x >= peak_pos + 15*peak_sigma, E[2:end]), length(W) - 7)

--- a/src/simple_cuts.jl
+++ b/src/simple_cuts.jl
@@ -16,6 +16,8 @@ function cut_single_peak(x::Vector{<:Unitful.RealOrRealQuantity}, min_x::T, max_
 
     # cut out window of interest
     x = x[(x .> min_x) .&& (x .< max_x)]
+    # fail clearly instead of an obscure reduce-empty error deep inside the histogram fit
+    isempty(x) && throw(ArgumentError("no entries in ($(min_x*x_unit), $(max_x*x_unit)), cannot locate a peak"))
 
     # fit histogram
     if n_bins < 0
@@ -44,7 +46,8 @@ function cut_single_peak(x::Vector{<:Unitful.RealOrRealQuantity}, min_x::T, max_
 
             # find left and right edge of peak
             cut_low_arg  = findfirst(w -> w >= relative_cut*cts_max, h.weights[1:cts_argmax])
-            cut_high_arg = findfirst(w -> w <= relative_cut*cts_max, h.weights[cts_argmax:end]) + cts_argmax - 1
+            # a peak flush against the window edge never drops below the relative cut: use the last edge
+            cut_high_arg = something(findfirst(w -> w <= relative_cut*cts_max, h.weights[cts_argmax:end]), length(h.weights) - cts_argmax + 2) + cts_argmax - 1
             cut_low, cut_high, cut_max = Array(h.edges[1])[cut_low_arg] * x_unit, Array(h.edges[1])[cut_high_arg] * x_unit, Array(h.edges[1])[cts_argmax] * x_unit
         else
             @debug "Cut window: [$cut_low, $cut_high]"


### PR DESCRIPTION
No change to successful fits — only what happens when a channel cannot be fitted:
- **`fit_fwhm_ft` / `fit_sf_wl`:** record the per-gridpoint skip reason (empty peak window,
  invalid peak-stats guess, < 100 events, SF outside (1, 100) %) and surface the counts in
  the error when no (resp. fewer than 2) grid points survive, with a hint (check the FEP
  peak / DEP-SEP statistics of this channel; det-specific override or usability change).
  `fit_sf_wl` now requires ≥ 2 valid points — a single point is no optimization and
  downstream report consumers assume a grid.
- **`cut_single_peak`:** clear error on an empty energy window; a peak flush against the
  window edge falls back to the last edge instead of `nothing + Int`.
- **`fit_calibration` / `fit_fwhm` / `peakstats`:** speaking `ArgumentError`s when no or too
  few peaks passed the fit QC (`Vector{Any}`/`Vector{Union{}}` inputs, `sort(peaks)[1:2]`
  BoundsError, sideband windows overlapping the peak with ≤ 14 bins).
