### PR TITLE
Support ArraysOfArrays v1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -57,7 +57,7 @@ LegendSpecFitsRecipesBaseExt = ["RecipesBase", "Plots"]
 
 [compat]
 ArgCheck = "1, 2"
-ArraysOfArrays = "0.5, 0.6"
+ArraysOfArrays = "0.5, 0.6, 1"
 BAT = "4.2"
 ChangesOfVariables = "0.1.3"
 DensityInterface = "0.4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LegendSpecFits"
 uuid = "18221496-77af-46cf-bab8-820da09f7f97"
-version = "0.4.7"
+version = "0.4.8"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"


### PR DESCRIPTION
Adds ArraysOfArrays v1 to the compat bounds, keeping support for the previous versions. All ArraysOfArrays API used here (`flatview` on arrays of similar arrays and on plain matrices, `ArrayOfSimilarArrays{<:Real}` / `VectorOfVectors{<:Real}` in signatures) is unchanged in v1.

CI can exercise ArraysOfArrays v1 only once EncodedArrays 0.5.0, LegendDataTypes 0.1.16 and BAT 4.3.2 are registered; until then the resolver keeps picking v0.6.

Includes a patch version bump.

Created by generative AI.
